### PR TITLE
Add missing requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto==2.38.0
 click==4.1
 paramiko==1.15.2
 PyYAML==3.11
+asyncio==3.4.3


### PR DESCRIPTION
This might be a glitch in my environment, but upon installing I found I was missing `ayncio`, and pip installing it did the trick. Not sure about the version to request, but here I just suggested the most recent one.