### PR TITLE
Add new Flintrock command: run-command

### DIFF
--- a/test-integration.sh
+++ b/test-integration.sh
@@ -31,6 +31,9 @@ if [ "$?" -ne 1 ]; then
 fi
 set -e
 
+test_echo "Run a command on a cluster."
+./flintrock run-command "$CLUSTER_NAME" -- ls -l
+
 test_echo "Stop a cluster."
 ./flintrock stop "$CLUSTER_NAME" --assume-yes
 


### PR DESCRIPTION
This partially addresses #4 by allowing you to run arbitrary shell commands against the nodes of your cluster.

Examples:

```sh
./flintrock run-command my-cluster 'touch /tmp/flintrock'
./flintrock run-command my-cluster -- yum install -y package
```

You just need to be careful to quote your command or delimit it with `--`. This prevents Flintrock from attempting to process any flags in your command, like `-y`.