### PR TITLE
Fixed inability to destroy clusters in other EC2 regions

### DIFF
--- a/flintrock.py
+++ b/flintrock.py
@@ -1540,6 +1540,7 @@ def config_to_click(config: dict) -> dict:
             list(ec2_configs.items()) +
             list(module_configs.items())),
         'describe': ec2_configs,
+        'destroy': ec2_configs,
         'login': ec2_configs,
         'start': ec2_configs,
         'stop': ec2_configs,


### PR DESCRIPTION
Currently we can't destroy non-us-west-1 clusters . This fixes  nchammas/flintrock/#32. 
