### PR TITLE
Add HDFS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here's a quick way to launch a cluster on EC2, assuming you already have an [AWS
 ```sh
 flintrock launch test-cluster \
     --num-slaves 1 \
+    --spark-version 1.5.1 \
     --ec2-key-name key_name \
     --ec2-identity-file /path/to/key.pem \
     --ec2-ami ami-146e2a7c \
@@ -141,6 +142,10 @@ Flintrock lets you persist your desired configuration to a file (called `config.
 
 ```yaml
 provider: ec2
+
+modules:
+  spark:
+    version: 1.5.1
 
 launch:
   num-slaves: 1

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -13,10 +13,10 @@ providers:
     instance-type: m3.medium  # must be 64-bit; small instances won't work
     region: us-east-1
     # availability-zone: <name>
-    # ami: ami-146e2a7c   # Amazon Linux
-    # user: ec2-user
-    ami: ami-61bbf104   # CentOS 7
-    user: centos
+    ami: ami-60b6c60a   # Amazon Linux
+    user: ec2-user
+    # ami: ami-61bbf104   # CentOS 7
+    # user: centos
     # spot-price: <price>
     # vpc-id: <id>
     # subnet-id: <id>

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -1,6 +1,8 @@
 modules:
   spark:
     version: 1.5.1
+  hdfs:
+    version: 2.7.1
 
 provider: ec2
 
@@ -25,3 +27,5 @@ providers:
 
 launch:
   num-slaves: 1
+  # install-hdfs: False
+  # install-spark: False

--- a/get-best-apache-mirror.py
+++ b/get-best-apache-mirror.py
@@ -1,0 +1,8 @@
+from __future__ import print_function
+
+import sys
+import urllib2
+import json
+
+mirror = json.loads(urllib2.urlopen(sys.argv[1]).read())
+print(mirror['preferred'] + mirror['path_info'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto==2.38.0
 click==5.1
-paramiko==1.15.3
+paramiko==1.15.4
 PyYAML==3.11

--- a/templates/hadoop/conf/core-site.xml
+++ b/templates/hadoop/conf/core-site.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value>/mnt/hdfs</value>
+  </property>
+
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://{master_host}:9000</value>
+  </property>
+</configuration>

--- a/templates/hadoop/conf/hadoop-env.sh
+++ b/templates/hadoop/conf/hadoop-env.sh
@@ -1,0 +1,2 @@
+export HADOOP_HOME="/home/{user}/hadoop"
+export HADOOP_SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=5"

--- a/templates/hadoop/conf/hdfs-site.xml
+++ b/templates/hadoop/conf/hdfs-site.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>dfs.blocksize</name>
+    <value>134217728</value>
+  </property>
+
+  <property>
+    <name>dfs.datanode.data.dir</name>
+    <value>/mnt/hdfs</value>
+  </property>
+</configuration>

--- a/templates/hadoop/conf/masters
+++ b/templates/hadoop/conf/masters
@@ -1,0 +1,1 @@
+{master_host}

--- a/templates/hadoop/conf/slaves
+++ b/templates/hadoop/conf/slaves
@@ -1,0 +1,1 @@
+{slave_hosts}

--- a/templates/spark/conf/slaves
+++ b/templates/spark/conf/slaves
@@ -1,0 +1,1 @@
+{slave_hosts}

--- a/templates/spark/conf/spark-env.sh
+++ b/templates/spark/conf/spark-env.sh
@@ -7,12 +7,10 @@ export SPARK_MASTER_OPTS="{spark_master_opts}"
 export SPARK_EXECUTOR_INSTANCES="1"
 export SPARK_WORKER_CORES="$(nproc)"
 
-export HADOOP_HOME=""
 export SPARK_MASTER_IP="{master_host}"
-export MASTER="spark://{master_host}:7077"
 
-export SPARK_SUBMIT_LIBRARY_PATH="$SPARK_SUBMIT_LIBRARY_PATH"
-export SPARK_SUBMIT_CLASSPATH="$SPARK_SUBMIT_CLASSPATH"
+# TODO: Make this dependent on HDFS install.
+export HADOOP_CONF_DIR="/home/{user}/hadoop/conf"
 
 # TODO: Make this non-EC2-specific.
 # Bind Spark's web UIs to this machine's public EC2 hostname


### PR DESCRIPTION
I have HDFS working, which you can test by running `hadoop/bin/hdfs`. Spark can also read stuff from HDFS with a simple `sc.textFile('hdfs:///file')`. And clusters can now be launched with any combination of HDFS or Spark installed by specifying `--no-install-hdfs` or `--no-install-spark`, or by setting the equivalent settings in `config.yaml`.

TODOs:
 - [x] Get Spark to talk to HDFS.
 - [x] Enforce Spark config dependency on HDFS install if necessary.
    * e.g. Add HDFS options to `ClusterInfo`.
 - [x] Clean up CLI option handling.
    * e.g. `spark_version` is required if `install_spark` is set.
 - [x] Allow neither HDFS nor Spark to be installed, per #20.
 - [x] Confirm HDFS comes up correctly after cluster restart.
 - [x] Abstract out login user from Hadoop config files.
 - [x] Clean up template handling for `slave_hosts`.

Fixes #40.
Fixes #20.