### PR TITLE
Configure root volume to be 30 GiB SSD

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -10,7 +10,7 @@ providers:
   ec2:
     key-name: key_name
     identity-file: /path/to/key.pem
-    instance-type: m3.medium  # must be 64-bit; small instances won't work
+    instance-type: m3.medium
     region: us-east-1
     # availability-zone: <name>
     ami: ami-60b6c60a   # Amazon Linux


### PR DESCRIPTION
Thanks to all the information provided by @ericmjonas, @broxtronix, and @shivaram in #28, I have this little feature working after some quick experimentation.

Flintrock now queries the AMI for the root volume name and configures it to be a 30 GiB SSD volume. I've tested this on both Amazon Linux and CentOS and it works correctly. In the future we may want to allow the user to configure the size of the root volume, but I'd rather add that after it's been asked for.

If this looks good to y'all, I'll merge it in and open a separate PR to cover the setup of additional ephemeral drives.

Partially addresses #28.