### PR TITLE
[WIP] Configure ephemeral storage

### DIFF
--- a/setup-ephemeral-storage.sh
+++ b/setup-ephemeral-storage.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# Install GNU parallel.
+if [ ! $(command -v parallel) ]; then
+    pushd /tmp
+    PARALLEL_VERSION="20151022"
+    wget "http://ftpmirror.gnu.org/parallel/parallel-${PARALLEL_VERSION}.tar.bz2"
+    bzip2 -dc "parallel-${PARALLEL_VERSION}.tar.bz2" | tar xvf -
+    pushd "parallel-${PARALLEL_VERSION}"
+    ./configure --prefix=/usr  # Amazon Linux root user doesn't have /usr/local on its $PATH
+    make
+    sudo make install
+    popd
+    rm -rf "./parallel-${PARALLEL_VERSION}*"
+    popd
+
+    # Suppress citation notice.
+    echo "will cite" | parallel --bibtex
+fi
+
+###
+
+root_device=$(
+    awk -F ' ' '$1~"^/dev" && $2=="/" {print $1}' /proc/mounts)
+mounted_non_root_devices=$(
+    awk -F ' ' '$1~"^/dev" && $2!="/" {print $1}' /proc/mounts)
+
+root_parent_device="${root_device%?}"
+
+non_root_devices=$(
+    lsblk --nodeps --list --noheadings --paths \
+    | awk -F ' ' --assign "r=$root_parent_device" '$1!~r {print $1}')
+
+if [ -n "$mounted_non_root_devices" ]; then
+    for device in $mounted_non_root_devices; do
+        sudo umount "$device"
+    done
+fi
+
+if [ -n "$non_root_devices" ]; then
+    echo "$non_root_devices" | parallel sudo mkfs.ext4 -F -E "lazy_itable_init=0,lazy_journal_init=0" "{}"
+
+    mount_num=1
+    for device in $non_root_devices; do
+        mount_name="/mnt${mount_num}"
+        sudo mkdir "$mount_name"
+        sudo mount -o "defaults,noatime,nodiratime" "$device" "$mount_name"
+        mount_num=$((mount_num + 1))
+    done
+fi


### PR DESCRIPTION
This is a work in progress.

If the instance [offers them](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes), Flintrock now automatically configures up to 12 ephemeral ext4-formatted volumes. The volumes are formatted in parallel, so the time it takes to format them is dependent only on the size of the largest volume, not on the number of volumes.

This means, for example, that Flintrock can setup 12 ephemeral volumes, 2TB each, in roughly 4 minutes (e.g. d2.4xlarge instances). I think that's pretty good.

I'm not happy with adding so much involved Bash, but I wonder if there is a cleaner way to accomplish what we want here. Perhaps later on we can convert this to Python.

It would be good to see what others think of this patch, and perhaps get it tested against a wider set of instance types than I've tested against. I've tested this against t2.small, m3.medium, d2.xlarge, d2.2xlarge, and d2.4xlarge instance types with Amazon Linux.

I couldn't get this working yet with CentOS because the base AMI they offer makes it very difficult to install GNU parallel from source: no wget, no bzip2, and no perl. There's also no official yum repository offering GNU parallel to make this easier. So maybe I'll have to convert some of this stuff to Python sooner than planned.

We will still need to configure HDFS to use these ephemeral volumes. That will come in a separate PR.