### PR TITLE
Configure HDFS and Spark to use available ephemeral storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,11 @@ Flintrock is really fast. This is how quickly it can launch fully operational cl
 
 The spark-ec2 launch times are sourced from [SPARK-5189](https://issues.apache.org/jira/browse/SPARK-5189).
 
-### Low-level Provider Options
+### Advanced Storage Setup
 
-#### EC2
+Flintrock automatically configures any available [ephemeral storage](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html) on the cluster and makes it available to installed modules like HDFS and Spark. This storage is fast and is perfect for use as a temporary store by those services.
+
+### Low-level Provider Options
 
 Flintrock exposes low-level provider options (e.g. [instance-initiated shutdown behavior](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior)) so you can control the details of how your cluster is setup if you want.
 

--- a/install-spark.sh
+++ b/install-spark.sh
@@ -2,7 +2,6 @@
 
 spark_version="$1"
 distribution="$2"
-spark_scratch_dir="$3"
 
 echo "Installing Spark..."
 echo "  version: ${spark_version}"
@@ -17,6 +16,3 @@ mkdir "spark"
 # strip-components puts the files in the root of spark/
 tar xzf "$file" -C "spark" --strip-components=1
 rm "$file"
-
-sudo mkdir "${spark_scratch_dir}"
-sudo chown "$(logname)":"$(logname)" "${spark_scratch_dir}"

--- a/templates/hadoop/conf/core-site.xml
+++ b/templates/hadoop/conf/core-site.xml
@@ -4,7 +4,7 @@
 <configuration>
   <property>
     <name>hadoop.tmp.dir</name>
-    <value>/mnt/hdfs</value>
+    <value>{root_ephemeral_dirs}</value>
   </property>
 
   <property>

--- a/templates/hadoop/conf/hdfs-site.xml
+++ b/templates/hadoop/conf/hdfs-site.xml
@@ -9,6 +9,6 @@
 
   <property>
     <name>dfs.datanode.data.dir</name>
-    <value>/mnt/hdfs</value>
+    <value>{root_ephemeral_dirs}</value>
   </property>
 </configuration>

--- a/templates/spark/conf/spark-env.sh
+++ b/templates/spark/conf/spark-env.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-export SPARK_LOCAL_DIRS="{spark_scratch_dir}"
+export SPARK_LOCAL_DIRS="{root_ephemeral_dirs}"
 
 # Standalone cluster options
-export SPARK_MASTER_OPTS="{spark_master_opts}"
 export SPARK_EXECUTOR_INSTANCES="1"
 export SPARK_WORKER_CORES="$(nproc)"
 


### PR DESCRIPTION
This change configures HDFS and Spark to use ephemeral storage when available.

The logic is as follows:
* If the cluster offers no ephemeral storage, point HDFS and Spark to the root volume, which is typically EBS-backed.
* If the cluster offers ephemeral storage, point HDFS and Spark at that and do not use the root volume.
  * In some cases, the available ephemeral storage will be smaller than the root volume, which may be confusing.

    m3.medium instances, for example, offer only 4GB of ephemeral storage, whereas the root volume is 30GB. That means you'll have *less* space available to HDFS and Spark with m3.medium instances than with, say, t2.small instances, since the latter have no ephemeral storage.

    In other words, HDFS gets 4GB of ephemeral storage with m3.medium instances, but 30GB of EBS storage from the root volume with t2.small instances.
* In no cases will HDFS or Spark be configured to use both the root volume and ephemeral volumes, since we would be mixing persistent with ephemeral storage. If this can be shown to be safe, I'm willing to change things so that both are used simultaneously.

Some of Flintrock's internals are getting a bit messier with this patch, but they will be relatively straightforward to refactor in the future. My focus for now is to get the primary functionality working.

I think we should discuss adding support for additional EBS volumes in a separate issue, so this PR fixes #28.