### PR TITLE
Add friendlier error message when the AMI cannot be found

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -15,9 +15,9 @@ providers:
     instance-type: m3.medium
     region: us-east-1
     # availability-zone: <name>
-    ami: ami-60b6c60a   # Amazon Linux
+    ami: ami-60b6c60a   # Amazon Linux, us-east-1
     user: ec2-user
-    # ami: ami-61bbf104   # CentOS 7
+    # ami: ami-61bbf104   # CentOS 7, us-east-1
     # user: centos
     # spot-price: <price>
     # vpc-id: <id>

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -2,8 +2,6 @@ import json
 import subprocess
 import urllib.request
 
-# TODO: Parallelize tests.
-
 
 def test_describe_stopped_cluster(stopped_cluster):
     p = subprocess.run([
@@ -106,3 +104,12 @@ def test_operations_against_non_existent_cluster():
             stderr=subprocess.PIPE)
         assert p.returncode == 1
         assert p.stderr.startswith(expected_error_message)
+
+
+def test_launch_with_bad_ami():
+    p = subprocess.run([
+        'flintrock', 'launch', 'whatever-cluster',
+        '--ec2-ami', 'ami-badbad00'],
+        stderr=subprocess.PIPE)
+    assert p.returncode == 1
+    assert p.stderr.startswith(b"Error: Could not find")


### PR DESCRIPTION
Instead of a large traceback, you now get this:

```sh
$ flintrock launch nick --ec2-ami ami-badbad00
Error: Could not find ami-badbad00 in region us-east-1.
```

I also added some comments to the config template to hint at the fact that AMIs are region-specific.

Fixes #65.