### PR TITLE
On failure, automatically retry Hadoop download a few times

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 ### Added
 
 * Added `--assume-yes` option to the `launch` command. Use `--assume-yes` to tell Flintrock to automatically destroy the cluster if there are problems during launch.
+* Automatically retry Hadoop download from flaky Apache mirrors.
 
 
 ## 0.1.0 - 2015-12-11

--- a/flintrock/download-hadoop.py
+++ b/flintrock/download-hadoop.py
@@ -1,0 +1,35 @@
+"""
+Download Hadoop from the best available Apache mirror.
+
+Python 2
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+import subprocess
+import urllib
+import urllib2
+import json
+
+hadoop_version = sys.argv[1]
+apache_mirror_url = "http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json".format(v=hadoop_version)
+
+tries = 0
+while tries < 3:
+    mirror_info = json.loads(urllib2.urlopen(apache_mirror_url).read())
+    file_url = mirror_info['preferred'] + mirror_info['path_info']
+    file_name = os.path.basename(mirror_info['path_info'])
+    print('Downloading file at:', file_url)
+
+    file_path, _ = urllib.urlretrieve(url=file_url, filename=file_name)
+    ret = subprocess.call(['gzip', '--test', file_path])
+
+    if ret == 0:
+        break
+    else:
+        tries += 1
+        print("gzip check failed. Retrying download...")
+
+sys.exit(ret)

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -179,16 +179,15 @@ class HDFS:
 
         with ssh_client.open_sftp() as sftp:
             sftp.put(
-                localpath=os.path.join(THIS_DIR, 'get-best-apache-mirror.py'),
-                remotepath='/tmp/get-best-apache-mirror.py')
+                localpath=os.path.join(THIS_DIR, 'download-hadoop.py'),
+                remotepath='/tmp/download-hadoop.py')
 
         ssh_check_output(
             client=ssh_client,
             command="""
                 set -e
 
-                curl --silent --remote-name "$(
-                    python /tmp/get-best-apache-mirror.py "http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{version}/hadoop-{version}.tar.gz?as_json")"
+                python /tmp/download-hadoop.py "{version}"
 
                 mkdir "hadoop"
                 mkdir "hadoop/conf"

--- a/flintrock/get-best-apache-mirror.py
+++ b/flintrock/get-best-apache-mirror.py
@@ -1,8 +1,0 @@
-from __future__ import print_function
-
-import sys
-import urllib2
-import json
-
-mirror = json.loads(urllib2.urlopen(sys.argv[1]).read())
-print(mirror['preferred'] + mirror['path_info'])


### PR DESCRIPTION
Flintrock will now try up to 3 different Apache mirrors when downloading Hadoop, if necessary.

This won't address the issue of slow mirrors, unfortunately, but it does cover the common case of a bad mirror just failing to serve up the Hadoop file we're interested in.

Fixes #66.