### PR TITLE
Check CLI option dependencies cleanly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ install:
   - "pip install -r requirements/developer.pip"
 script:
   - "py.test ./tests/test_static.py"
+  - "py.test ./tests/test_flintrock.py"

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -15,6 +15,7 @@ import click
 from .core import FlintrockCluster
 from .core import provision_cluster
 from .exceptions import (
+    Error,
     ClusterNotFound,
     ClusterAlreadyExists,
     ClusterInvalidState,
@@ -402,7 +403,7 @@ def launch(
             region=region)
     except boto.exception.EC2ResponseError as e:
         if e.error_code == 'InvalidAMIID.NotFound':
-            raise Exception(
+            raise Error(
                 "Error: Could not find {ami} in region {region}.".format(
                     ami=ami,
                     region=region))

--- a/flintrock/exceptions.py
+++ b/flintrock/exceptions.py
@@ -1,3 +1,7 @@
+class NothingToDo(Exception):
+    pass
+
+
 class UsageError(Exception):
     pass
 
@@ -9,19 +13,19 @@ class UnsupportedProviderError(UsageError):
         self.provider = provider
 
 
-class NothingToDo(Exception):
+class Error(Exception):
     pass
 
 
-class ClusterNotFound(Exception):
+class ClusterNotFound(Error):
     pass
 
 
-class ClusterAlreadyExists(Exception):
+class ClusterAlreadyExists(Error):
     pass
 
 
-class ClusterInvalidState(Exception):
+class ClusterInvalidState(Error):
     def __init__(self, *, attempted_command: str, state: str):
         super().__init__(
             "Cluster is in state '{s}'. Cannot execute {c}.".format(
@@ -31,7 +35,7 @@ class ClusterInvalidState(Exception):
         self.state = state
 
 
-class NodeError(Exception):
+class NodeError(Error):
     def __init__(self, error: str):
         super().__init__(
             "At least one node raised an error: " + error)

--- a/tests/test_flintrock.py
+++ b/tests/test_flintrock.py
@@ -1,0 +1,128 @@
+# External modules
+import pytest
+
+# Flintrock modules
+from flintrock.exceptions import (
+    UsageError
+)
+from flintrock.flintrock import (
+    option_name_to_variable_name,
+    variable_name_to_option_name,
+    option_requires,
+    mutually_exclusive
+)
+
+
+def test_option_name_to_variable_name_conversions():
+    test_cases = [
+        ('--ec2-user', 'ec2_user'),
+        ('--provider', 'provider'),
+        ('--spark-git-commit', 'spark_git_commit')
+    ]
+
+    for option_name, variable_name in test_cases:
+        assert option_name_to_variable_name(option_name) == variable_name
+        assert variable_name_to_option_name(variable_name) == option_name
+        assert option_name == variable_name_to_option_name(
+            option_name_to_variable_name(option_name))
+        assert variable_name == option_name_to_variable_name(
+            variable_name_to_option_name(variable_name))
+
+
+def test_option_requires():
+    unset_option = None
+    set_option = '와 짠이다'
+
+    option_requires(
+        option='--some-option',
+        requires_all=['--set_option'],
+        scope=locals()
+    )
+
+    option_requires(
+        option='--some-option',
+        requires_any=[
+            '--set_option',
+            '--unset-option'],
+        scope=locals()
+    )
+
+    with pytest.raises(UsageError):
+        option_requires(
+            option='--some-option',
+            requires_all=[
+                '--set-option',
+                '--unset-option'],
+            scope=locals()
+        )
+
+    with pytest.raises(UsageError):
+        option_requires(
+            option='--some-option',
+            requires_any=[
+                '--unset-option'],
+            scope=locals()
+        )
+
+
+def test_option_requires_conditional_value():
+    with pytest.raises(Exception):
+        option_requires(
+            option='--some-option',
+            conditional_value='magic',
+            requires_any=[
+                '--set_option',
+                '--unset-option'],
+            scope=locals()
+        )
+
+    some_option = 'not magic'
+    option_requires(
+        option='--some-option',
+        conditional_value='magic',
+        requires_any=[
+            '--set_option',
+            '--unset-option'],
+        scope=locals()
+    )
+
+    some_option = 'magic'
+    with pytest.raises(UsageError):
+        option_requires(
+            option='--some-option',
+            conditional_value='magic',
+            requires_any=[
+                '--set_option',
+                '--unset-option'],
+            scope=locals()
+        )
+
+    some_option = ''
+    with pytest.raises(UsageError):
+        option_requires(
+            option='--some-option',
+            conditional_value='',
+            requires_any=[
+                '--set_option',
+                '--unset-option'],
+            scope=locals()
+        )
+
+
+def test_mutually_exclusive():
+    option1 = 'yes'
+    option2 = None
+
+    mutually_exclusive(
+        options=[
+            '--option1',
+            '--option2'],
+        scope=locals())
+
+    option2 = 'no'
+    with pytest.raises(UsageError):
+        mutually_exclusive(
+            options=[
+                '--option1',
+                '--option2'],
+            scope=locals())


### PR DESCRIPTION
Option dependencies that could not be checked directly using Click are now checked using a few new utility functions. This means users get nice, fast error messages when they don't provide the right options to Flintrock, rather than getting some ugly barf from EC2 or worse--having Flintrock launch an unusable cluster.

For example, before this PR:

```
$ flintrock launch nick
Launching 2 instances...
Exception: Error reading SSH protocol banner
Traceback (most recent call last):
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/transport.py", line 1724, in _check_banner
    buf = self.packetizer.readline(timeout)
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/packet.py", line 326, in readline
    buf += self._read_timeout(timeout)
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/packet.py", line 481, in _read_timeout
    raise EOFError()
EOFError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/transport.py", line 1594, in run
    self._check_banner()
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/transport.py", line 1728, in _check_banner
    raise SSHException('Error reading SSH protocol banner' + str(e))
paramiko.ssh_exception.SSHException: Error reading SSH protocol banner

Exception: Error reading SSH protocol banner[Errno 54] Connection reset by peer
Traceback (most recent call last):
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/transport.py", line 1724, in _check_banner
    buf = self.packetizer.readline(timeout)
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/packet.py", line 326, in readline
    buf += self._read_timeout(timeout)
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/packet.py", line 479, in _read_timeout
    x = self.__socket.recv(128)
ConnectionResetError: [Errno 54] Connection reset by peer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/transport.py", line 1594, in run
    self._check_banner()
  File ".../flintrock/venv/lib/python3.5/site-packages/paramiko/transport.py", line 1728, in _check_banner
    raise SSHException('Error reading SSH protocol banner' + str(e))
paramiko.ssh_exception.SSHException: Error reading SSH protocol banner[Errno 54] Connection reset by peer

At least one node raised an error: Error reading SSH protocol banner
Do you want to terminate the 2 instances created by this operation? [Y/n]: 
Terminating instances...
At least one node raised an error: Error reading SSH protocol banner
```

And with this PR:

```
Error: Missing option "--ec2-key-name" is required by "--provider ec2".
```

Before this PR:

```
$ flintrock launch nick
EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidAMIID.Malformed</Code><Message>Invalid id: "None" (expecting "ami-...")</Message></Error></Errors><RequestID>275a403d-da32-4bce-81d7-e02f2e66fb18</RequestID></Response>
```

With this PR:

```
Error: Missing option "--ec2-ami" is required by "--provider ec2".
```

Fixes #5.