### PR TITLE
Upgrade to boto3

### DIFF
--- a/flintrock/exceptions.py
+++ b/flintrock/exceptions.py
@@ -35,6 +35,10 @@ class ClusterInvalidState(Error):
         self.state = state
 
 
+class SSHError(Error):
+    pass
+
+
 class NodeError(Error):
     def __init__(self, error: str):
         super().__init__(

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -180,14 +180,16 @@ def cli(cli_context, config, provider):
               help="Path to SSH .pem file for accessing nodes.")
 @click.option('--ec2-instance-type', default='m3.medium', show_default=True)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
-@click.option('--ec2-availability-zone')
+# We set some of these defaults to empty strings because of boto3's parameter validation.
+# See: https://github.com/boto/boto3/issues/400
+@click.option('--ec2-availability-zone', default='')
 @click.option('--ec2-ami')
 @click.option('--ec2-user')
 @click.option('--ec2-spot-price', type=float)
-@click.option('--ec2-vpc-id')
-@click.option('--ec2-subnet-id')
-@click.option('--ec2-instance-profile-name')
-@click.option('--ec2-placement-group')
+@click.option('--ec2-vpc-id', default='')
+@click.option('--ec2-subnet-id', default='')
+@click.option('--ec2-instance-profile-name', default='')
+@click.option('--ec2-placement-group', default='')
 @click.option('--ec2-tenancy', default='default')
 @click.option('--ec2-ebs-optimized/--no-ec2-ebs-optimized', default=False)
 @click.option('--ec2-instance-initiated-shutdown-behavior', default='stop',

--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -8,6 +8,9 @@ from collections import namedtuple
 # External modules
 import paramiko
 
+# Flintrock modules
+from .exceptions import SSHError
+
 
 def generate_ssh_key_pair() -> namedtuple('KeyPair', ['public', 'private']):
     """
@@ -98,7 +101,7 @@ def ssh_check_output(client: paramiko.client.SSHClient, command: str):
         #       See: https://docs.python.org/3/library/subprocess.html#subprocess.check_output
         # NOTE: We are losing the output order here since output from stdout and stderr
         #       may be interleaved.
-        raise Exception(stdout_output + stderr_output)
+        raise SSHError(stdout_output + stderr_output)
 
     return stdout_output
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setuptools.setup(
     # totally break Flintrock.
     # For example: https://github.com/paramiko/paramiko/issues/615
     install_requires=[
-        'boto == 2.38.0',
+        'boto3 == 1.2.3',
+        'botocore == 1.3.20',
         'click == 6.2',
         'paramiko == 1.15.4',
         'PyYAML == 3.11'


### PR DESCRIPTION
This PR upgrades Flintrock to use boto3, the Amazon-backed replacement for boto.

In the process, I also cleaned up a few minor things:
* `cluster.master_ip`, `cluster.slave_ips`, and family are now all derived attributes.
* Flintrock errors (as opposed to command errors from the cluster) are no longer hidden by `NodeError`.
* Template variables are now cleanly enumerated inside the definition of `FlintrockCluster`.

Fixes #22.