### PR TITLE
Migrate from Paramiko + Threads to AsyncSSH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
 install:
   - "pip install -r requirements/developer.pip"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ That's not all. Flintrock has a few more [features](#features) that you may find
 
 Before using Flintrock, take a quick look at the [copyright](https://github.com/nchammas/flintrock/blob/master/COPYRIGHT) notice and [license](https://github.com/nchammas/flintrock/blob/master/LICENSE) and make sure you're OK with their terms.
 
-**Flintrock requires Python 3.4 or newer**, unless you are using one of our **standalone packages**. Flintrock has been thoroughly tested only on OS X, but it should run on all POSIX systems. We have plans to [add Windows support](https://github.com/nchammas/flintrock/issues/46) in the future, too.
+**Flintrock requires Python 3.5 or newer**, unless you are using one of our **standalone packages**. Flintrock has been thoroughly tested only on OS X, but it should run on all POSIX systems. We have plans to [add Windows support](https://github.com/nchammas/flintrock/issues/46) in the future, too.
 
 ### Release version
 

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -1,5 +1,3 @@
-import asyncio
-import concurrent.futures
 import functools
 import json
 import os
@@ -9,8 +7,11 @@ import sys
 import time
 
 # Flintrock modules
-from .exceptions import SSHError, NodeError
-from .ssh import get_ssh_client, ssh_check_output, ssh
+from .ssh import (
+    get_ssh_client,
+    ssh_run,
+    ssh)
+from .util import run_against_hosts, sync_run
 
 FROZEN = getattr(sys, 'frozen', False)
 
@@ -134,21 +135,23 @@ class FlintrockCluster:
         """
         Start up all the services installed on the cluster.
 
-        This method assumes that the nodes constituting cluster were just
+        This method assumes that the nodes constituting the cluster were just
         started up by the provider (e.g. EC2, GCE, etc.) they're hosted on
         and are running.
         """
-        master_ssh_client = get_ssh_client(
-            user=user,
-            host=self.master_ip,
-            identity_file=identity_file)
+        master_ssh_client = sync_run(
+            get_ssh_client(
+                user=user,
+                host=self.master_ip,
+                identity_file=identity_file))
 
         with master_ssh_client:
-            manifest_raw = ssh_check_output(
-                client=master_ssh_client,
-                command="""
-                    cat /home/{u}/.flintrock-manifest.json
-                """.format(u=shlex.quote(user)))
+            manifest_raw = sync_run(
+                ssh_run(
+                    client=master_ssh_client,
+                    command="""
+                        cat /home/{u}/.flintrock-manifest.json
+                    """.format(u=shlex.quote(user))))
             # TODO: Reconsider where this belongs. In the manifest? We can implement
             #       ephemeral storage support as a Flintrock service, and add methods to
             #       serialize and deserialize critical service info like installed versions
@@ -158,14 +161,15 @@ class FlintrockCluster:
             #       instance type.
             # NOTE: As for why we aren't using ls here, see:
             #       http://mywiki.wooledge.org/ParsingLs
-            ephemeral_dirs_raw = ssh_check_output(
-                client=master_ssh_client,
-                command="""
-                    shopt -s nullglob
-                    for f in /media/ephemeral*; do
-                        echo "$f"
-                    done
-                """)
+            ephemeral_dirs_raw = sync_run(
+                ssh_run(
+                    client=master_ssh_client,
+                    command="""
+                        shopt -s nullglob
+                        for f in /media/ephemeral*; do
+                            echo "$f"
+                        done
+                    """))
 
         manifest = json.loads(manifest_raw)
         storage_dirs = StorageDirs(
@@ -180,7 +184,7 @@ class FlintrockCluster:
             service = globals()[service_name](**manifest)
             services.append(service)
 
-        partial_func = functools.partial(
+        start_node_partial = functools.partial(
             start_node,
             services=services,
             user=user,
@@ -188,12 +192,13 @@ class FlintrockCluster:
             cluster=self)
         hosts = [self.master_ip] + self.slave_ips
 
-        _run_asynchronously(partial_func=partial_func, hosts=hosts)
+        run_against_hosts(async_partial_func=start_node_partial, hosts=hosts)
 
-        master_ssh_client = get_ssh_client(
-            user=user,
-            host=self.master_ip,
-            identity_file=identity_file)
+        master_ssh_client = sync_run(
+            get_ssh_client(
+                user=user,
+                host=self.master_ip,
+                identity_file=identity_file))
 
         with master_ssh_client:
             for service in services:
@@ -254,14 +259,14 @@ class FlintrockCluster:
         else:
             target_hosts = [self.master_ip] + self.slave_ips
 
-        partial_func = functools.partial(
+        run_command_node_partial = functools.partial(
             run_command_node,
             user=user,
             identity_file=identity_file,
             command=command)
         hosts = target_hosts
 
-        _run_asynchronously(partial_func=partial_func, hosts=hosts)
+        run_against_hosts(async_partial_func=run_command_node_partial, hosts=hosts)
 
     def copy_file_check(self):
         """
@@ -291,7 +296,7 @@ class FlintrockCluster:
         else:
             target_hosts = [self.master_ip] + self.slave_ips
 
-        partial_func = functools.partial(
+        copy_file_node_partial = functools.partial(
             copy_file_node,
             user=user,
             identity_file=identity_file,
@@ -299,7 +304,7 @@ class FlintrockCluster:
             remote_path=remote_path)
         hosts = target_hosts
 
-        _run_asynchronously(partial_func=partial_func, hosts=hosts)
+        run_against_hosts(async_partial_func=copy_file_node_partial, hosts=hosts)
 
     def login(
             self,
@@ -340,46 +345,6 @@ class FlintrockCluster:
         return template_mapping
 
 
-def _run_asynchronously(*, partial_func: functools.partial, hosts: list):
-    """
-    Run a function asynchronously against each of the provided hosts.
-
-    This function assumes that partial_func accepts `host` as a keyword argument.
-    """
-    loop = asyncio.get_event_loop()
-    executor = concurrent.futures.ThreadPoolExecutor(len(hosts))
-
-    tasks = []
-    for host in hosts:
-        # TODO: Use parameter names for run_in_executor() once Python 3.4.4 is released.
-        #       Until then, we leave them out to maintain compatibility across Python 3.4
-        #       and 3.5.
-        # See: http://stackoverflow.com/q/32873974/
-        task = loop.run_in_executor(
-            executor,
-            functools.partial(partial_func, host=host))
-        tasks.append(task)
-
-    try:
-        loop.run_until_complete(asyncio.gather(*tasks))
-        # done, _ = loop.run_until_complete(asyncio.wait(tasks))
-        # # Is this the right way to make sure no coroutine failed?
-        # for future in done:
-        #     future.result()
-    except SSHError as e:
-        raise NodeError(str(e))
-    finally:
-        # TODO: Let KeyboardInterrupt cleanly cancel hung commands.
-        #       Currently, we can't do this without dumping a large stack trace or
-        #       waiting until the executor threads yield control.
-        #       See: http://stackoverflow.com/q/29177490/
-        # We shutdown explcitly to make sure threads are cleaned up before shutting
-        # the loop down.
-        # See: http://stackoverflow.com/a/32615276/
-        executor.shutdown(wait=True)
-        loop.close()
-
-
 def provision_cluster(
         *,
         cluster: FlintrockCluster,
@@ -389,7 +354,7 @@ def provision_cluster(
     """
     Connect to a freshly launched cluster and install the specified services.
     """
-    partial_func = functools.partial(
+    provision_node_partial = functools.partial(
         provision_node,
         services=services,
         user=user,
@@ -397,25 +362,27 @@ def provision_cluster(
         cluster=cluster)
     hosts = [cluster.master_ip] + cluster.slave_ips
 
-    _run_asynchronously(partial_func=partial_func, hosts=hosts)
+    run_against_hosts(async_partial_func=provision_node_partial, hosts=hosts)
 
-    master_ssh_client = get_ssh_client(
-        user=user,
-        host=cluster.master_host,
-        identity_file=identity_file)
+    master_ssh_client = sync_run(
+        get_ssh_client(
+            user=user,
+            host=cluster.master_host,
+            identity_file=identity_file))
 
     with master_ssh_client:
         manifest = {
             'services': [[type(m).__name__, m.manifest] for m in services]}
         # The manifest tells us how the cluster is configured. We'll need this
         # when we resize the cluster or restart it.
-        ssh_check_output(
-            client=master_ssh_client,
-            command="""
-                echo {m} > /home/{u}/.flintrock-manifest.json
-            """.format(
-                m=shlex.quote(json.dumps(manifest, indent=4, sort_keys=True)),
-                u=shlex.quote(user)))
+        sync_run(
+            ssh_run(
+                client=master_ssh_client,
+                command="""
+                    echo {m} > /home/{u}/.flintrock-manifest.json
+                """.format(
+                    m=shlex.quote(json.dumps(manifest, indent=4, sort_keys=True)),
+                    u=shlex.quote(user))))
 
         for service in services:
             service.configure_master(
@@ -432,7 +399,7 @@ def provision_cluster(
         service.health_check(master_host=cluster.master_host)
 
 
-def provision_node(
+async def provision_node(
         *,
         services: list,
         user: str,
@@ -444,16 +411,15 @@ def provision_node(
     storage, and install the specified services.
 
     This method is role-agnostic; it runs on both the cluster master and slaves.
-    This method is meant to be called asynchronously.
     """
-    client = get_ssh_client(
+    client = await get_ssh_client(
         user=user,
         host=host,
         identity_file=identity_file,
         print_status=True)
 
     with client:
-        ssh_check_output(
+        await ssh_run(
             client=client,
             command="""
                 set -e
@@ -466,15 +432,15 @@ def provision_node(
                 private_key=shlex.quote(cluster.ssh_key_pair.private),
                 public_key=shlex.quote(cluster.ssh_key_pair.public)))
 
-        with client.open_sftp() as sftp:
-            sftp.put(
-                localpath=os.path.join(SCRIPTS_DIR, 'setup-ephemeral-storage.py'),
+        with (await client.start_sftp_client()) as sftp:
+            await sftp.put(
+                localpaths=os.path.join(SCRIPTS_DIR, 'setup-ephemeral-storage.py'),
                 remotepath='/tmp/setup-ephemeral-storage.py')
 
         print("[{h}] Configuring ephemeral storage...".format(h=host))
         # TODO: Print some kind of warning if storage is large, since formatting
         #       will take several minutes (~4 minutes for 2TB).
-        storage_dirs_raw = ssh_check_output(
+        storage_dirs_raw = await ssh_run(
             client=client,
             command="""
                 set -e
@@ -487,7 +453,7 @@ def provision_node(
         cluster.storage_dirs.ephemeral = storage_dirs['ephemeral']
 
         # The default CentOS AMIs on EC2 don't come with Java installed.
-        java_home = ssh_check_output(
+        java_home = await ssh_run(
             client=client,
             command="""
                 echo "$JAVA_HOME"
@@ -496,7 +462,7 @@ def provision_node(
         if not java_home.strip():
             print("[{h}] Installing Java...".format(h=host))
 
-            ssh_check_output(
+            await ssh_run(
                 client=client,
                 command="""
                     set -e
@@ -507,15 +473,15 @@ def provision_node(
                 """)
 
         for service in services:
-            service.install(
+            await service.install(
                 ssh_client=client,
                 cluster=cluster)
-            service.configure(
+            await service.configure(
                 ssh_client=client,
                 cluster=cluster)
 
 
-def start_node(
+async def start_node(
         *,
         services: list,
         user: str,
@@ -527,9 +493,8 @@ def start_node(
     work.
 
     This method is role-agnostic; it runs on both the cluster master and slaves.
-    This method is meant to be called asynchronously.
     """
-    ssh_client = get_ssh_client(
+    ssh_client = await get_ssh_client(
         user=user,
         host=host,
         identity_file=identity_file,
@@ -539,7 +504,7 @@ def start_node(
         # TODO: Consider consolidating ephemeral storage code under a dedicated
         #       Flintrock service.
         if cluster.storage_dirs.ephemeral:
-            ssh_check_output(
+            await ssh_run(
                 client=ssh_client,
                 command="""
                     sudo chown "{u}:{u}" {d}
@@ -548,20 +513,19 @@ def start_node(
                     d=' '.join(cluster.storage_dirs.ephemeral)))
 
         for service in services:
-            service.configure(
+            await service.configure(
                 ssh_client=ssh_client,
                 cluster=cluster)
 
 
-def run_command_node(*, user: str, host: str, identity_file: str, command: tuple):
+async def run_command_node(*, user: str, host: str, identity_file: str, command: tuple):
     """
     Run a shell command on a node.
 
     This method is role-agnostic; it runs on both the cluster master and slaves.
-    This method is meant to be called asynchronously.
     """
     # TODO: Timeout quickly if SSH is not available.
-    ssh_client = get_ssh_client(
+    ssh_client = await get_ssh_client(
         user=user,
         host=host,
         identity_file=identity_file)
@@ -571,14 +535,14 @@ def run_command_node(*, user: str, host: str, identity_file: str, command: tuple
     command_str = ' '.join(command)
 
     with ssh_client:
-        ssh_check_output(
+        await ssh_run(
             client=ssh_client,
             command=command_str)
 
     print("[{h}] Command complete.".format(h=host))
 
 
-def copy_file_node(
+async def copy_file_node(
         *,
         user: str,
         host: str,
@@ -589,10 +553,9 @@ def copy_file_node(
     Copy a file to the specified remote path on a node.
 
     This method is role-agnostic; it runs on both the cluster master and slaves.
-    This method is meant to be called asynchronously.
     """
     # TODO: Timeout quickly if SSH is not available.
-    ssh_client = get_ssh_client(
+    ssh_client = await get_ssh_client(
         user=user,
         host=host,
         identity_file=identity_file)
@@ -601,7 +564,7 @@ def copy_file_node(
         remote_dir = posixpath.dirname(remote_path)
 
         try:
-            ssh_check_output(
+            await ssh_run(
                 client=ssh_client,
                 command="""
                     test -d {path}
@@ -610,10 +573,10 @@ def copy_file_node(
             # TODO: Catch more specific exception.
             raise Exception("Remote directory does not exist: {d}".format(d=remote_dir))
 
-        with ssh_client.open_sftp() as sftp:
+        with (await ssh_client.start_sftp_client()) as sftp:
             print("[{h}] Copying file...".format(h=host))
 
-            sftp.put(localpath=local_path, remotepath=remote_path)
+            await sftp.put(localpaths=local_path, remotepath=remote_path)
 
             print("[{h}] Copy complete.".format(h=host))
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -20,6 +20,7 @@ from .exceptions import (
     Error)
 from flintrock import __version__
 from .services import HDFS, Spark  # TODO: Remove this dependency.
+from .util import flintrock_is_in_development_mode
 
 FROZEN = getattr(sys, 'frozen', False)
 
@@ -741,23 +742,6 @@ def configure(cli_context, locate):
         os.chmod(config_file, mode=0o644)
 
     click.launch(config_file, locate=locate)
-
-
-def flintrock_is_in_development_mode() -> bool:
-    """
-    Check if Flintrock was installed in development mode.
-
-    Use this function to toggle behavior that only Flintrock developers should
-    see.
-    """
-    # This esoteric technique was pulled from pip.
-    # See: https://github.com/pypa/pip/pull/3258/files#diff-ab583908279e865537dec218246edcfcR310
-    for path_item in sys.path:
-        egg_link = os.path.join(path_item, 'Flintrock.egg-link')
-        if os.path.isfile(egg_link):
-            return True
-    else:
-        return False
 
 
 def set_open_files_limit(desired_limit):

--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -1,3 +1,4 @@
+import asyncio
 import errno
 import os
 import socket
@@ -7,7 +8,7 @@ import time
 from collections import namedtuple
 
 # External modules
-import paramiko
+import asyncssh
 
 # Flintrock modules
 from .exceptions import SSHError
@@ -36,74 +37,70 @@ def generate_ssh_key_pair() -> namedtuple('KeyPair', ['public', 'private']):
     return namedtuple('KeyPair', ['public', 'private'])(public_key, private_key)
 
 
-def get_ssh_client(
+async def get_ssh_client(
         *,
         user: str,
         host: str,
         identity_file: str,
-        # TODO: Add option to not wait for SSH availability.
-        print_status: bool=False) -> paramiko.client.SSHClient:
+        print_status: bool=False) -> asyncssh.SSHClientConnection:
     """
     Get an SSH client for the provided host, waiting as necessary for SSH to become
     available.
     """
-    # paramiko.common.logging.basicConfig(level=paramiko.common.DEBUG)
-
-    client = paramiko.client.SSHClient()
-
-    client.load_system_host_keys()
-    client.set_missing_host_key_policy(paramiko.client.AutoAddPolicy())
-
+    # TODO: Add option to not wait for SSH availability.
+    client_key = asyncssh.read_private_key(identity_file)
     while True:
         try:
-            client.connect(
-                username=user,
-                hostname=host,
-                key_filename=identity_file,
-                look_for_keys=False,
+            client = await asyncio.wait_for(
+                asyncssh.connect(
+                    host=host,
+                    username=user,
+                    known_hosts=None,
+                    client_keys=[client_key]),
                 timeout=3)
             if print_status:
                 print("[{h}] SSH online.".format(h=host))
             break
-        # TODO: Somehow rationalize these expected exceptions.
-        # TODO: Add some kind of limit on number of failures.
-        except socket.timeout as e:
-            time.sleep(5)
         except socket.error as e:
             if e.errno != errno.ECONNREFUSED:
                 raise
-            time.sleep(5)
-        # We get this exception during startup with CentOS but not Amazon Linux,
-        # for some reason.
-        except paramiko.ssh_exception.AuthenticationException as e:
-            time.sleep(5)
+            else:
+                await asyncio.sleep(5)
+        except asyncio.TimeoutError as e:
+            await asyncio.sleep(5)
 
     return client
 
 
-def ssh_check_output(client: paramiko.client.SSHClient, command: str):
+async def ssh_run(
+        *,
+        client: asyncssh.SSHClientConnection,
+        command: str,
+        input: str=None,
+        timeout: int=None,  # seconds
+        check: bool=True):
     """
-    Run a command via the provided SSH client and return the output captured
-    on stdout.
-
-    Raise an exception if the command returns a non-zero code.
+    Inspired by: https://docs.python.org/3/library/subprocess.html#subprocess.run
     """
-    stdin, stdout, stderr = client.exec_command(command, get_pty=True)
+    stdin, stdout, stderr = await asyncio.wait_for(
+        client.open_session(
+            command=command,
+            term_type='xterm'),  # This gets us a TTY, which we need for sudo.
+        timeout=timeout)
 
-    # NOTE: Paramiko doesn't clearly document this, but we must read() before
-    #       calling recv_exit_status().
-    #       See: https://github.com/paramiko/paramiko/issues/448#issuecomment-159481997
-    stdout_output = stdout.read().decode('utf8').rstrip('\n')
-    stderr_output = stderr.read().decode('utf8').rstrip('\n')
-    exit_status = stdout.channel.recv_exit_status()
+    if input is not None:
+        stdin.write(input)
+        stdin.write_eof()
 
-    if exit_status:
-        # TODO: Return a custom exception that includes the return code.
-        #       See: https://docs.python.org/3/library/subprocess.html#subprocess.check_output
-        # NOTE: We are losing the output order here since output from stdout and stderr
-        #       may be interleaved.
-        raise SSHError(stdout_output + stderr_output)
+    stdout_output = (await stdout.read()).rstrip('\n')
+    stderr_output = (await stderr.read()).rstrip('\n')
+    exit_status = stdout.channel.get_exit_status()
 
+    if check and exit_status:
+        # TODO: Exception attributes for returncode
+        raise SSHError(stderr_output)
+
+    # TODO: Return class with stdout, stderr, and returncode.
     return stdout_output
 
 

--- a/flintrock/util.py
+++ b/flintrock/util.py
@@ -1,0 +1,58 @@
+import asyncio
+import functools
+import os
+import sys
+
+# Flintrock modules
+from .exceptions import SSHError, NodeError
+
+
+def flintrock_is_in_development_mode() -> bool:
+    """
+    Check if Flintrock was installed in development mode.
+
+    Use this function to toggle behavior that only Flintrock developers should
+    see.
+    """
+    # This esoteric technique was pulled from pip.
+    # See: https://github.com/pypa/pip/pull/3258/files#diff-ab583908279e865537dec218246edcfcR310
+    for path_item in sys.path:
+        egg_link = os.path.join(path_item, 'Flintrock.egg-link')
+        if os.path.isfile(egg_link):
+            return True
+    else:
+        return False
+
+
+def run_against_hosts(*, async_partial_func: functools.partial, hosts: list):
+    """
+    Run an asynchronous function against a group of hosts.
+
+    async_partial_func must accept `host` as a keyword argument.
+    """
+    loop = asyncio.get_event_loop()
+
+    if flintrock_is_in_development_mode():
+        loop.set_debug(True)
+
+    tasks = []
+    for host in hosts:
+        task = asyncio.ensure_future(async_partial_func(host=host))
+        tasks.append(task)
+
+    # TODO: Let KeyboardInterrupt cleanly cancel hung commands.
+    try:
+        loop.run_until_complete(asyncio.gather(*tasks))
+        # done, _ = loop.run_until_complete(asyncio.wait(tasks))
+        # # Is this the right way to make sure no coroutine failed?
+        # for future in done:
+        #     future.result()
+    except SSHError as e:
+        raise NodeError(str(e))
+
+
+def sync_run(coro_or_future):
+    """
+    Run a coroutine or future synchronously and return the result.
+    """
+    return asyncio.get_event_loop().run_until_complete(coro_or_future)

--- a/generate-standalone-package.py
+++ b/generate-standalone-package.py
@@ -23,6 +23,10 @@ if __name__ == '__main__':
             # We won't need this when this issue is resolved:
             # https://github.com/pyinstaller/pyinstaller/issues/1844
             '--hidden-import', 'html.parser',
+            # This hidden import is for AsyncSSH / Cryptography.
+            # It will become unnecessary with resolution of this issue:
+            # https://github.com/pyinstaller/pyinstaller/issues/1425
+            '--hidden-import', '_cffi_backend',
             'standalone.py'],
         check=True)
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
 
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
     keywords=['Apache Spark'],
@@ -49,15 +48,11 @@ setuptools.setup(
     # totally break Flintrock.
     # For example: https://github.com/paramiko/paramiko/issues/615
     install_requires=[
+        'asyncssh == 1.5.2',
         'boto3 == 1.2.6',
         'botocore == 1.4.1',
         'click == 6.3',
-        'paramiko == 1.15.4',
-        'PyYAML == 3.11',
-        # This is to make PyInstaller work, since dateutil 2.5.0
-        # packaging appears to be broken.
-        # See: https://github.com/pyinstaller/pyinstaller/issues/1848
-        'python-dateutil == 2.4.2',
+        'PyYAML == 3.11'
     ],
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,11 @@ setuptools.setup(
         'boto3 == 1.2.6',
         'botocore == 1.4.1',
         'click == 6.3',
-        'PyYAML == 3.11'
+        'PyYAML == 3.11',
+        # This is to make PyInstaller work, since dateutil 2.5.0
+        # packaging appears to be broken.
+        # See: https://github.com/pyinstaller/pyinstaller/issues/1848
+        'python-dateutil == 2.4.2',
     ],
 
     entry_points={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import tempfile
+import time
 import uuid
 from collections import OrderedDict
 
@@ -95,7 +96,9 @@ def running_cluster(request):
         spark_git_commit=request.param.spark_git_commit)
 
     if request.param.restarted:
+        time.sleep(5)
         stop_cluster(cluster_name)
+        time.sleep(5)
         start_cluster(cluster_name)
 
     def destroy():


### PR DESCRIPTION
This PR migrates Flintrock from Paramiko + Threads to AsyncSSH. The hope is that dropping the need for threads and fully utilizing asyncio will reduce Flintrock's memory footprint and, more importantly, speed up all cluster operations.
 
This is a work in progress. Remaining items:

- [x] Understand why launches are _slower_ with AsyncSSH, which is a surprising result.
- [x] Remove remaining, non-concurent uses of Paramiko, like for master configuration.
- [ ] Implement clean exit when the user hits Control + C during an operation.

Fixes #9.