### PR TITLE
Add PyInstaller hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv/
 flintrock-logo/
 .hypothesis/
 *.prf
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ python:
   - "3.5"
 install:
   - "pip install -r requirements/developer.pip"
+  - "curl -L -o pandoc.deb https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb && sudo dpkg -i pandoc.deb"
 script:
   - "py.test ./tests/test_static.py"
   - "py.test ./tests/test_flintrock.py"
+  - "py.test ./tests/test_pyinstaller_packaging.py"
+addons:
+  artifacts:
+    paths:
+      - "dist/*.zip"
+  s3_region: "us-east-1"

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -5,13 +5,20 @@ import json
 import os
 import posixpath
 import shlex
+import sys
 import time
 
 # Flintrock modules
 from .exceptions import SSHError, NodeError
 from .ssh import get_ssh_client, ssh_check_output, ssh
 
-THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+FROZEN = getattr(sys, 'frozen', False)
+
+if FROZEN:
+    THIS_DIR = sys._MEIPASS
+else:
+    THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
 SCRIPTS_DIR = os.path.join(THIS_DIR, 'scripts')
 
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -21,7 +21,12 @@ from .exceptions import (
 from flintrock import __version__
 from .services import HDFS, Spark  # TODO: Remove this dependency.
 
-THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+FROZEN = getattr(sys, 'frozen', False)
+
+if FROZEN:
+    THIS_DIR = sys._MEIPASS
+else:
+    THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 def format_message(*, message: str, indent: int=4, wrap: int=70):

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -12,7 +12,13 @@ import paramiko
 from .core import FlintrockCluster
 from .ssh import ssh_check_output
 
-THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+FROZEN = getattr(sys, 'frozen', False)
+
+if FROZEN:
+    THIS_DIR = sys._MEIPASS
+else:
+    THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
 SCRIPTS_DIR = os.path.join(THIS_DIR, 'scripts')
 
 

--- a/generate-standalone-package.py
+++ b/generate-standalone-package.py
@@ -1,0 +1,30 @@
+import os
+import platform
+import shutil
+import subprocess
+
+from flintrock import __version__ as flintrock_version
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
+if __name__ == '__main__':
+    operating_system = platform.system()
+    machine_type = platform.machine()
+
+    subprocess.run([
+            'pyinstaller',
+            '--noconfirm',
+            '--name', 'flintrock',
+            '--additional-hooks-dir', '.',
+            'standalone.py'],
+        check=True)
+
+    shutil.make_archive(
+        base_name=os.path.join(
+            THIS_DIR, 'dist',
+            'flintrock-{v}-{os}-{m}'.format(
+                v=flintrock_version,
+                os=operating_system,
+                m=machine_type)),
+        format='zip',
+        root_dir=os.path.join(THIS_DIR, 'dist', 'flintrock'))

--- a/hook-flintrock.py
+++ b/hook-flintrock.py
@@ -1,0 +1,5 @@
+datas=[
+    ('flintrock/scripts', './scripts'),
+    ('flintrock/templates', './templates'),
+    ('flintrock/config.yaml.template', './'),
+]

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -2,3 +2,4 @@
 wheel >= 0.26.0
 twine >= 1.6.4
 pypandoc >= 1.1.2
+PyInstaller >= 3.1

--- a/requirements/user.pip
+++ b/requirements/user.pip
@@ -1,7 +1,10 @@
 # NOTE: Run pip from Flintrock's root directory, not from the directory containing
 #       this file.
+
+# Due to: https://github.com/pyinstaller/pyinstaller/issues/1781
+setuptools >= 19.0, <= 19.2
+
 # NOTE: The `-e .` syntax lets us reuse the requirements already specified under
 #       `install_requires` in setup.py.
 #       See: https://caremad.io/2013/07/setup-vs-requirement/
-setuptools >= 18.8.1
 -e .

--- a/standalone.py
+++ b/standalone.py
@@ -1,0 +1,11 @@
+"""
+A standalone script for use by PyInstaller.
+
+Users should not be running this script.
+"""
+
+import sys
+from flintrock.flintrock import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -1,0 +1,20 @@
+import glob
+import subprocess
+import sys
+
+# External modules
+import pytest
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ is required")
+def test_pyinstaller_packaging():
+    subprocess.run(
+        ['pip', 'install', '-r', 'requirements/maintainer.pip'],
+        check=True)
+    subprocess.run(
+        ['python', 'generate-standalone-package.py'],
+        check=True)
+    subprocess.run(
+        ['./dist/flintrock/flintrock'],
+        check=True)
+    assert glob.glob('./dist/*.zip')


### PR DESCRIPTION
This PR add hooks that PyInstaller can use to package Flintrock up into a standalone package that people can run without needing Python pre-installed on their system.

I'll also try as part of this PR to automate the process of generating and uploading standalone packages for Linux via Travis.

Fixes #75.