### PR TITLE
Add support for non-default VPCs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 ### Added
 
 * [#98](https://github.com/nchammas/flintrock/pull/98)/[#99](https://github.com/nchammas/flintrock/pull/99): You can now specify `latest` for `--spark-git-commit` and Flintrock will automatically build Spark on your cluster at the latest commit. This feature is only available for repos hosted on GitHub.
+* [#94](https://github.com/nchammas/flintrock/pull/94): Flintrock now supports launching clusters into non-default VPCs.
 
 ### Changed
 
@@ -19,6 +20,7 @@
 ### Changed
 
 * [`eca59fc`](https://github.com/nchammas/flintrock/commit/eca59fc0052874d9aa48b7d4d7d79192b5e609d1), [`3cf6ee6`](https://github.com/nchammas/flintrock/commit/3cf6ee64162ceaac6429d79c3bc6ef25988eaa8e): Tweaked a few things so that Flintrock can launch 200+ node clusters without hitting certain limits.
+
 
 ## [0.2.0](https://github.com/nchammas/flintrock/compare/v0.1.0...v0.2.0) - 2016-02-07
 

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -9,7 +9,7 @@ import sys
 import time
 
 # Flintrock modules
-from .exceptions import SSHError, NodeError
+from .exceptions import SSHError
 from .ssh import get_ssh_client, ssh_check_output, ssh
 
 FROZEN = getattr(sys, 'frozen', False)
@@ -141,7 +141,9 @@ class FlintrockCluster:
         master_ssh_client = get_ssh_client(
             user=user,
             host=self.master_ip,
-            identity_file=identity_file)
+            identity_file=identity_file,
+            wait=True,
+            print_status=False)
 
         with master_ssh_client:
             manifest_raw = ssh_check_output(
@@ -366,8 +368,6 @@ def _run_asynchronously(*, partial_func: functools.partial, hosts: list):
         # # Is this the right way to make sure no coroutine failed?
         # for future in done:
         #     future.result()
-    except SSHError as e:
-        raise NodeError(str(e))
     finally:
         # TODO: Let KeyboardInterrupt cleanly cancel hung commands.
         #       Currently, we can't do this without dumping a large stack trace or
@@ -450,7 +450,7 @@ def provision_node(
         user=user,
         host=host,
         identity_file=identity_file,
-        print_status=True)
+        wait=True)
 
     with client:
         ssh_check_output(
@@ -533,7 +533,7 @@ def start_node(
         user=user,
         host=host,
         identity_file=identity_file,
-        print_status=True)
+        wait=True)
 
     with ssh_client:
         # TODO: Consider consolidating ephemeral storage code under a dedicated
@@ -560,7 +560,6 @@ def run_command_node(*, user: str, host: str, identity_file: str, command: tuple
     This method is role-agnostic; it runs on both the cluster master and slaves.
     This method is meant to be called asynchronously.
     """
-    # TODO: Timeout quickly if SSH is not available.
     ssh_client = get_ssh_client(
         user=user,
         host=host,
@@ -591,7 +590,6 @@ def copy_file_node(
     This method is role-agnostic; it runs on both the cluster master and slaves.
     This method is meant to be called asynchronously.
     """
-    # TODO: Timeout quickly if SSH is not available.
     ssh_client = get_ssh_client(
         user=user,
         host=host,

--- a/flintrock/exceptions.py
+++ b/flintrock/exceptions.py
@@ -36,11 +36,8 @@ class ClusterInvalidState(Error):
 
 
 class SSHError(Error):
-    pass
-
-
-class NodeError(Error):
-    def __init__(self, error: str):
+    def __init__(self, *, host: str, message: str):
         super().__init__(
-            "At least one node raised an error: " + error)
-        self.error = error
+            "[{h}] {m}".format(h=host, m=message))
+        self.host = host
+        self.message = message

--- a/tests/test_flintrock.py
+++ b/tests/test_flintrock.py
@@ -32,6 +32,7 @@ def test_option_name_to_variable_name_conversions():
 
 
 def test_option_requires():
+    some_option = 'something'
     unset_option = None
     set_option = '와 짠이다'
 
@@ -68,44 +69,43 @@ def test_option_requires():
 
 
 def test_option_requires_conditional_value():
-    with pytest.raises(Exception):
-        option_requires(
-            option='--some-option',
-            conditional_value='magic',
-            requires_any=[
-                '--set_option',
-                '--unset-option'],
-            scope=locals()
-        )
+    unset_option = None
+    set_option = '대박'
+
+    some_option = 'magic'
+    option_requires(
+        option='--some-option',
+        conditional_value='magic',
+        requires_any=[
+            '--set-option',
+            '--unset-option'],
+        scope=locals()
+    )
 
     some_option = 'not magic'
     option_requires(
         option='--some-option',
         conditional_value='magic',
         requires_any=[
-            '--set_option',
             '--unset-option'],
         scope=locals()
     )
 
-    some_option = 'magic'
+    some_option = ''
+    option_requires(
+        option='--some-option',
+        conditional_value='',
+        requires_any=[
+            '--unset-option'],
+        scope=locals()
+    )
+
     with pytest.raises(UsageError):
+        some_option = 'magic'
         option_requires(
             option='--some-option',
             conditional_value='magic',
             requires_any=[
-                '--set_option',
-                '--unset-option'],
-            scope=locals()
-        )
-
-    some_option = ''
-    with pytest.raises(UsageError):
-        option_requires(
-            option='--some-option',
-            conditional_value='',
-            requires_any=[
-                '--set_option',
                 '--unset-option'],
             scope=locals()
         )


### PR DESCRIPTION
The discussion in #85 and #92 revealed that Flintrock has thus far assumed that everyone works with a default VPC, and this is not true. If you created your AWS account in or before 2013, you very likely don't have a default VPC.

This PR adds support for non-default VPCs. The relevant reading is here:

* http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html
* https://forums.aws.amazon.com/thread.jspa?messageID=707417
* https://github.com/mitchellh/packer/issues/1935#issuecomment-111235752

To summarize the key points from the above links, as well as the key changes in this PR:

1. Security groups are scoped to a VPC, and Flintrock clusters are identified by security group. This means that all Flintrock commands that need to identify a cluster now accept a VPC parameter.
2. If you do not specify the VPC you want, Flintrock will query EC2 for the default VPC in your region. This is how Flintrock worked before this PR, but now that logic has been formalized and Flintrock will give a clean error message if you have no default VPC set in your selected region.
3. When you specify the VPC explicitly, Flintrock assumes it's a non-default VPC and requires that you specify a subnet explicitly since users currently are unable to set default subnets on non-default VPCs. Flintrock will additionally check that your non-default VPC and subnet are configured correctly.

@dhulse @marcuscollins - I've tested this PR thoroughly, but it would be a big help if you tested this in your environments and confirmed that it works for you as expected. The key things to test are the 3 points I just laid out above.

To install Flintrock at this PR, use this command:

```
pip3 install -U git+https://github.com/nchammas/flintrock@non-default-vpc
```

This will override any installation of Flintrock you have in your currently-active environment.

Fixes #85.
Fixes #92.
