### PR TITLE
Make download-hadoop.py Python 2/3 compatible

### DIFF
--- a/flintrock/scripts/download-hadoop.py
+++ b/flintrock/scripts/download-hadoop.py
@@ -1,35 +1,39 @@
 """
 Download Hadoop from the best available Apache mirror.
-
-Python 2
 """
 
 from __future__ import print_function
 
+import json
 import os
 import sys
 import subprocess
-import urllib
-import urllib2
-import json
 
-hadoop_version = sys.argv[1]
-apache_mirror_url = "http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json".format(v=hadoop_version)
+if sys.version_info < (3, 0):
+    from urllib import urlretrieve
+    from urllib2 import urlopen
+else:
+    from urllib.request import urlopen, urlretrieve
 
-tries = 0
-while tries < 3:
-    mirror_info = json.loads(urllib2.urlopen(apache_mirror_url).read())
-    file_url = mirror_info['preferred'] + mirror_info['path_info']
-    file_name = os.path.basename(mirror_info['path_info'])
-    print('Downloading file at:', file_url)
 
-    file_path, _ = urllib.urlretrieve(url=file_url, filename=file_name)
-    ret = subprocess.call(['gzip', '--test', file_path])
+if __name__ == '__main__':
+    hadoop_version = sys.argv[1]
+    apache_mirror_url = "http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json".format(v=hadoop_version)
 
-    if ret == 0:
-        break
-    else:
-        tries += 1
-        print("gzip check failed. Retrying download...")
+    tries = 0
+    while tries < 3:
+        mirror_info = json.loads(urlopen(apache_mirror_url).read().decode('utf-8'))
+        file_url = mirror_info['preferred'] + mirror_info['path_info']
+        file_name = os.path.basename(mirror_info['path_info'])
+        print('Downloading file at:', file_url)
 
-sys.exit(ret)
+        file_path, _ = urlretrieve(url=file_url, filename=file_name)
+        ret = subprocess.call(['gzip', '--test', file_path])
+
+        if ret == 0:
+            break
+        else:
+            tries += 1
+            print("gzip check failed. Retrying download...")
+
+    sys.exit(ret)


### PR DESCRIPTION
This should be the last change required to get Flintrock to work with AMIs that have Python 3 as the default Python.

I haven't tested this with a full launch. I've just tested the download script individually from my laptop to make sure it works with both Python 2 and 3.