### PR TITLE
add security rule : open port 7077 from client 

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -367,6 +367,12 @@ def get_or_create_ec2_security_groups(
             from_port=4040,
             to_port=4040,
             cidr_ip=flintrock_client_cidr,
+            src_group=None),
+        SecurityGroupRule(
+            ip_protocol='tcp',
+            from_port=7077,
+            to_port=7077,
+            cidr_ip=flintrock_client_cidr,
             src_group=None)
     ]
 


### PR DESCRIPTION
Open the port 7077, so clients ( e.g. zeppelin ) can connect to the spark master like described in the issue #102 