### PR TITLE
Add security rule: open port 6066 from client

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -374,6 +374,7 @@ def get_or_create_ec2_security_groups(
             to_port=7077,
             cidr_ip=flintrock_client_cidr,
             src_group=None),
+        # Spark REST Server
         SecurityGroupRule(
             ip_protocol='tcp',
             from_port=6066,

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -373,6 +373,12 @@ def get_or_create_ec2_security_groups(
             from_port=7077,
             to_port=7077,
             cidr_ip=flintrock_client_cidr,
+            src_group=None),
+        SecurityGroupRule(
+            ip_protocol='tcp',
+            from_port=6066,
+            to_port=6066,
+            cidr_ip=flintrock_client_cidr,
             src_group=None)
     ]
 


### PR DESCRIPTION
This PR makes the following changes:
* open port 6066 from client, to allow '--deploy-mode cluster' when submitting jobs

I tested this PR by submitting a spark job from a remote client (a host that does not belong to the spark cluster) : `spark-submit --deploy-mode cluster --master spark://host:6066`