### PR TITLE
Add add-slaves and remove-slaves commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,22 @@
 
 ## [Unreleased]
 
-Nothing notable yet.
-
 [Unreleased]: https://github.com/nchammas/flintrock/compare/v0.5.0...master
+
+### Added
+
+* [#115]: Flintrock can now resize existing clusters with the new
+  `add-slaves` and `remove-slaves` commands.
+
+[#115]: https://github.com/nchammas/flintrock/pull/115
+
+### Changed
+
+* [#115]: If you lost your master somehow, Flintrock can now still
+  destroy the cluster.
+* [#115]: You can no longer launch clusters with 0 slaves. The
+  implementation was broken. We may fix and add this capability back
+  in the future.
 
 ## [0.5.0] - 2016-07-20
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Other things you can do with Flintrock include:
 ```sh
 flintrock login test-cluster
 flintrock describe test-cluster
+flintrock add-slaves test-cluster --num-slaves 2
+flintrock remove-slaves test-cluster --num-slaves 1
 flintrock run-command test-cluster 'sudo yum install -y package'
 flintrock copy-file test-cluster /local/path /remote/path
 ```

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -35,6 +35,7 @@ providers:
     # security-groups:
     #   - group-name1
     #   - group-name2
+    # instance-profile-name:
     tenancy: default  # default | dedicated
     ebs-optimized: no  # yes | no
     instance-initiated-shutdown-behavior: terminate  # terminate | stop

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -89,6 +89,20 @@ class FlintrockCluster:
         """
         raise NotImplementedError
 
+    @property
+    def num_slaves(self) -> int:
+        """
+        How many slaves the cluster has.
+
+        This is typically just len(self.slave_ips), but we need a separate
+        property because slave IPs are not available when the cluster is
+        stopped, and sometimes in that situation we still want to know how
+        many slaves there are.
+
+        Providers must override this property.
+        """
+        raise NotImplementedError
+
     def load_manifest(self, *, user: str, identity_file: str):
         """
         Load a cluster's manifest from the master. This will populate information
@@ -243,11 +257,9 @@ class FlintrockCluster:
 
             remove_slaves(self, user: str, identity_file: str, num_slaves: int)
 
-        The provider should pick which slaves to remove given the requested
-        number, and then pass the addresses of those specific slaves to this
-        method.
-
-        This method should be called before/after... (?)
+        This method should be called after the provider has removed the slaves
+        from the cluster's internal list but before the instances themselves
+        have been terminated.
 
         This method simply makes sure that the rest of the cluster knows that
         the relevant slaves are no longer part of the cluster.

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -90,6 +90,18 @@ class FlintrockCluster:
         raise NotImplementedError
 
     @property
+    def num_masters(self) -> int:
+        """
+        How many masters the cluster has.
+
+        This normally just equals 1, but in cases where the cluster master
+        has been destroyed this should return 0.
+
+        Providers must override this property.
+        """
+        raise NotImplementedError
+
+    @property
     def num_slaves(self) -> int:
         """
         How many slaves the cluster has.
@@ -246,6 +258,12 @@ class FlintrockCluster:
         There's currently nothing to do here, but this method should be called
         before the underlying provider stops the nodes.
         """
+        pass
+
+    def add_slaves_check(self):
+        pass
+
+    def add_slaves(self, *, user: str, identity_file: str):
         pass
 
     # We can probably do without this method in core and just use service.configure().

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -735,9 +735,6 @@ def remove_slaves_node(
             ssh_client=ssh_client,
             cluster=cluster)
 
-    # TODO: Restart master? If we don't do that, Spark, for example, will keep the
-    #       removed slaves around and mark them as dead.
-
 
 def run_command_node(*, user: str, host: str, identity_file: str, command: tuple):
     """

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -368,8 +368,10 @@ class EC2Cluster(FlintrockCluster):
         print('  state: {s}'.format(s=self.state))
         print('  node-count: {nc}'.format(nc=len(self.instances)))
         if self.state == 'running':
-            print('  master:', self.master_host)
-            print('\n    - '.join(['  slaves:'] + self.slave_hosts))
+            print('  master:', self.master_host if self.num_masters > 0 else '')
+            print(
+                '\n    - '.join(
+                    ['  slaves:'] + (self.slave_hosts if self.num_slaves > 0 else [])))
         # print('...')
 
 

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -297,8 +297,14 @@ class EC2Cluster(FlintrockCluster):
         ec2 = boto3.resource(service_name='ec2', region_name=self.region)
 
         # self.remove_slaves_check() (?)
+
+        # Remove spot instances first, if any.
+        _instances = sorted(
+            self.slave_instances,
+            key=lambda x: x.instance_lifecycle == 'spot',
+            reverse=True)
         removed_slave_instances, self.slave_instances = \
-            self.slave_instances[0:num_slaves], self.slave_instances[num_slaves:]
+            _instances[0:num_slaves], _instances[num_slaves:]
 
         if self.state == 'running':
             super().remove_slaves(user=user, identity_file=identity_file)

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -216,8 +216,7 @@ class EC2Cluster(FlintrockCluster):
             user: str,
             identity_file: str,
             num_slaves: int,
-            spot_price: float
-        ):
+            spot_price: float):
         security_group_ids = [
             group['GroupId']
             for group in self.master_instance.security_groups]

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -636,9 +636,6 @@ def remove_slaves(
                 n=num_slaves))
         num_slaves = cluster.num_slaves
 
-    # TODO:
-    #   * Does Spark need to be restarted if cluster is running? (No?)
-
     if not assume_yes:
         cluster.print()
         click.confirm(

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -605,6 +605,9 @@ def add_slaves(
         ec2_spot_price):
     """
     Add slaves to an existing cluster.
+
+    Flintrock will configure new slaves based on information queried
+    automatically from the master.
     """
     provider = cli_context.obj['provider']
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -642,11 +642,6 @@ def add_slaves(
         identity_file=identity_file)
     cluster.add_slaves_check()
 
-    print("Adding {n} slave{s}..."
-          .format(
-              n=num_slaves,
-              s='' if num_slaves == 1 else 's'))
-
     if provider == 'ec2':
         cluster.add_slaves(
             user=user,
@@ -701,11 +696,13 @@ def remove_slaves(
 
     if num_slaves > cluster.num_slaves:
         print(
-            "Warning: Cluster has {c} slaves. "
-            "You asked to remove {n} slaves."
+            "Warning: Cluster has {c} slave{cs}. "
+            "You asked to remove {n} slave{ns}."
             .format(
                 c=cluster.num_slaves,
-                n=num_slaves))
+                cs='' if cluster.num_slaves == 1 else 's',
+                n=num_slaves,
+                ns='' if num_slaves == 1 else 's'))
         num_slaves = cluster.num_slaves
 
     if not assume_yes:

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -176,7 +176,7 @@ def cli(cli_context, config, provider):
 
 @cli.command()
 @click.argument('cluster-name')
-@click.option('--num-slaves', type=click.IntRange(min=0), required=True)
+@click.option('--num-slaves', type=click.IntRange(min=1), required=True)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
 @click.option('--hdfs-version')
 @click.option('--hdfs-download-source',
@@ -627,12 +627,17 @@ def remove_slaves(
     else:
         raise UnsupportedProviderError(provider)
 
-    # TODO:
-    #   * Show warning if requested is more than available. Remove available.
-    #   * Does Spark need to be restarted if cluster is running? (No?)
-    #   * Make sure cluster can be launched with 0 slaves. (?)
+    if num_slaves > cluster.num_slaves:
+        print(
+            "Warning: Cluster has {c} slaves. "
+            "You asked to remove {n} slaves."
+            .format(
+                c=cluster.num_slaves,
+                n=num_slaves))
+        num_slaves = cluster.num_slaves
 
-    # cluster.remove_slaves_check() ?
+    # TODO:
+    #   * Does Spark need to be restarted if cluster is running? (No?)
 
     if not assume_yes:
         cluster.print()

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -583,6 +583,85 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
     print("{c} is now stopped.".format(c=cluster_name))
 
 
+@cli.command(name='remove-slaves')
+@click.argument('cluster-name')
+@click.option('--num-slaves', type=int, required=True)
+@click.option('--ec2-region', default='us-east-1', show_default=True)
+@click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
+@click.option('--ec2-user')
+@click.option('--ec2-identity-file',
+              type=click.Path(exists=True, dir_okay=False),
+              help="Path to SSH .pem file for accessing nodes.")
+@click.option('--assume-yes/--no-assume-yes', default=False)
+@click.pass_context
+def remove_slaves(
+        cli_context,
+        cluster_name,
+        num_slaves,
+        ec2_region,
+        ec2_vpc_id,
+        ec2_user,
+        ec2_identity_file,
+        assume_yes):
+    """
+    Remove slaves from an existing cluster.
+    """
+    provider = cli_context.obj['provider']
+
+    option_requires(
+        option='--provider',
+        conditional_value='ec2',
+        requires_all=[
+            '--ec2-region',
+            '--ec2-user',
+            '--ec2-identity-file'],
+        scope=locals())
+
+    if provider == 'ec2':
+        cluster = ec2.get_cluster(
+            cluster_name=cluster_name,
+            region=ec2_region,
+            vpc_id=ec2_vpc_id)
+        user = ec2_user
+        identity_file = ec2_identity_file
+    else:
+        raise UnsupportedProviderError(provider)
+
+    # START HERE
+    # * How do we query the number of slaves when the cluster is stopped?
+    # * Can we remove slaves?
+    #   * Show warning if requested is more than available.
+    #   * e.g. cluster has 4 slaves, user asks to remove 5
+    # * Should we allow all slaves to be removed? (Yes?)
+    # * Terminate instances
+    # * Does the cluster need to be started at this point? (Yes?)
+    # * Update `slaves` file on all nodes
+    # * Does Spark need to be restarted? (No?)
+    # * Make sure cluster can be launched with 0 slaves. (?)
+    # * NOTE: cluster start will autoamtically fix slaves file (?)
+
+    # cluster.remove_slaves_check() ?
+
+    if not assume_yes:
+        cluster.print()
+        click.confirm(
+            text=("Are you sure you want to remove {n} slave{s} from this cluster?"
+                .format(
+                    n=num_slaves,
+                    s='' if num_slaves == 1 else 's')),
+            abort=True)
+
+    print("Removing {n} slave{s}..."
+        .format(
+            n=num_slaves,
+            s='' if num_slaves == 1 else 's'))
+    cluster.remove_slaves(
+        user=user,
+        identity_file=identity_file,
+        num_slaves=num_slaves)
+    # print("Cluster now has {n} slaves.".format(n=))
+
+
 @cli.command(name='run-command')
 @click.argument('cluster-name')
 @click.argument('command', nargs=-1)
@@ -793,6 +872,7 @@ def config_to_click(config: dict) -> dict:
         'login': ec2_configs,
         'start': ec2_configs,
         'stop': ec2_configs,
+        'remove-slaves': ec2_configs,
         'run-command': ec2_configs,
         'copy-file': ec2_configs,
     }

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -176,7 +176,7 @@ def cli(cli_context, config, provider):
 
 @cli.command()
 @click.argument('cluster-name')
-@click.option('--num-slaves', type=int, required=True)
+@click.option('--num-slaves', type=click.IntRange(min=0), required=True)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
 @click.option('--hdfs-version')
 @click.option('--hdfs-download-source',
@@ -585,7 +585,7 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 
 @cli.command(name='remove-slaves')
 @click.argument('cluster-name')
-@click.option('--num-slaves', type=int, required=True)
+@click.option('--num-slaves', type=click.IntRange(min=1), required=True)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
 @click.option('--ec2-user')
@@ -627,18 +627,10 @@ def remove_slaves(
     else:
         raise UnsupportedProviderError(provider)
 
-    # START HERE
-    # * How do we query the number of slaves when the cluster is stopped?
-    # * Can we remove slaves?
-    #   * Show warning if requested is more than available.
-    #   * e.g. cluster has 4 slaves, user asks to remove 5
-    # * Should we allow all slaves to be removed? (Yes?)
-    # * Terminate instances
-    # * Does the cluster need to be started at this point? (Yes?)
-    # * Update `slaves` file on all nodes
-    # * Does Spark need to be restarted? (No?)
-    # * Make sure cluster can be launched with 0 slaves. (?)
-    # * NOTE: cluster start will autoamtically fix slaves file (?)
+    # TODO:
+    #   * Show warning if requested is more than available. Remove available.
+    #   * Does Spark need to be restarted if cluster is running? (No?)
+    #   * Make sure cluster can be launched with 0 slaves. (?)
 
     # cluster.remove_slaves_check() ?
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -637,6 +637,9 @@ def add_slaves(
             .format(
                 c=cluster_name))
 
+    cluster.load_manifest(
+        user=user,
+        identity_file=identity_file)
     cluster.add_slaves_check()
 
     print("Adding {n} slave{s}..."

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -640,15 +640,15 @@ def remove_slaves(
         cluster.print()
         click.confirm(
             text=("Are you sure you want to remove {n} slave{s} from this cluster?"
-                .format(
-                    n=num_slaves,
-                    s='' if num_slaves == 1 else 's')),
+                  .format(
+                      n=num_slaves,
+                      s='' if num_slaves == 1 else 's')),
             abort=True)
 
     print("Removing {n} slave{s}..."
-        .format(
-            n=num_slaves,
-            s='' if num_slaves == 1 else 's'))
+          .format(
+              n=num_slaves,
+              s='' if num_slaves == 1 else 's'))
     cluster.remove_slaves(
         user=user,
         identity_file=identity_file,

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -287,6 +287,8 @@ class Spark(FlintrockService):
             self,
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
+        # import pudb
+        # pudb.set_trace()
         template_paths = [
             'spark/conf/spark-env.sh',
             'spark/conf/slaves']

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -180,8 +180,6 @@ class HDFS(FlintrockService):
         ssh_check_output(
             client=ssh_client,
             command="""
-                ./hadoop/sbin/stop-dfs.sh
-                sleep 3
                 ./hadoop/bin/hdfs namenode -format -nonInteractive
                 ./hadoop/sbin/start-dfs.sh
             """)
@@ -321,13 +319,7 @@ class Spark(FlintrockService):
         ssh_check_output(
             client=ssh_client,
             command="""
-                set -e
-
-                spark/sbin/stop-master.sh
-                sleep 3
-                spark/sbin/start-master.sh
-
-                set +e
+                spark/sbin/start-all.sh
 
                 master_ui_response_code=0
                 while [ "$master_ui_response_code" -ne 200 ]; do
@@ -337,10 +329,6 @@ class Spark(FlintrockService):
                              --write-out "%{{http_code}}" {m}:8080
                     )"
                 done
-
-                set -e
-
-                spark/sbin/start-slaves.sh
             """.format(
                 m=shlex.quote(cluster.master_host)))
 

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -180,6 +180,8 @@ class HDFS(FlintrockService):
         ssh_check_output(
             client=ssh_client,
             command="""
+                ./hadoop/sbin/stop-dfs.sh
+                sleep 3
                 ./hadoop/bin/hdfs namenode -format -nonInteractive
                 ./hadoop/sbin/start-dfs.sh
             """)
@@ -287,8 +289,6 @@ class Spark(FlintrockService):
             self,
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
-        # import pudb
-        # pudb.set_trace()
         template_paths = [
             'spark/conf/spark-env.sh',
             'spark/conf/slaves']
@@ -323,6 +323,8 @@ class Spark(FlintrockService):
             command="""
                 set -e
 
+                spark/sbin/stop-master.sh
+                sleep 3
                 spark/sbin/start-master.sh
 
                 set +e

--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -12,8 +12,10 @@ import paramiko
 # Flintrock modules
 from .exceptions import SSHError
 
+SSHKeyPair = namedtuple('KeyPair', ['public', 'private'])
 
-def generate_ssh_key_pair() -> namedtuple('KeyPair', ['public', 'private']):
+
+def generate_ssh_key_pair() -> SSHKeyPair:
     """
     Generate an SSH key pair that the cluster can use for intra-cluster
     communication.

--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -6,7 +6,7 @@ export SPARK_LOCAL_DIRS="{root_ephemeral_dirs}"
 export SPARK_EXECUTOR_INSTANCES="1"
 export SPARK_WORKER_CORES="$(nproc)"
 
-export SPARK_MASTER_IP="{master_host}"
+export SPARK_MASTER_HOST="{master_host}"
 
 # TODO: Make this dependent on HDFS install.
 export HADOOP_CONF_DIR="/home/$(logname)/hadoop/conf"


### PR DESCRIPTION
This PR is a work in progress.

This PR adds `add-slaves` and `remove-slaves` commands which enable the user to resize existing clusters. `add-slaves` will query the master for its configuration and automatically use that information to provision new slaves. The only configuration the user may want to specify is the spot price for new slaves.

The PR also fixes a number of bugs, including a surprising config problem I discovered (	0c9a24b; how did it not stand out before? 🤔) that may have been causing sporadic problems. These bugs were interfering with my ability to test this PR, so I thought it would be good to fix them as part of this work.

TODO:
- [x] Implement `add-slaves`.
- [x] Implement `remove-slaves`.
- [x] Update README. 
- [x] Protect all calls to `instances.filter()` from empty input. (see https://github.com/boto/boto3/issues/479)
- [x] Update help text for the new commands.
- [x] ~~Add acceptance tests.~~

    Will defer this till later since the full test suite already takes too long, and since testing this properly is a bit difficult.
 
Open questions:
 - Does the Spark master need to be restarted
    - [x] when slaves are removed from a running cluster? **No.**
    - [x] when slaves are added to a running cluster? **No.**
 - Does the HDFS master need to be restarted
    - [x] when slaves are removed from a running cluster? **No?**

      HDFS seems to work properly, though warnings are thrown when you add new files due to the dead slaves. `hdfs dfsadmin -report` still shows the removed slaves, and `hdfs dfsadmin -refreshNodes` doesn't seem to remove them from the report that `dfsadmin` shows. I'm not sure if this is OK.
    - [x] when slaves are added to a running cluster? **No.**

Fixes #16.
Fixes #113.
Fixes #140.
