### PR TITLE
fix documentation bug where providers was left off

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,13 +191,14 @@ services:
 launch:
   num-slaves: 1
 
-ec2:
-  key-name: key_name
-  identity-file: /path/to/.ssh/key.pem
-  instance-type: m3.medium
-  region: us-east-1
-  ami: ami-08111162
-  user: ec2-user
+providers:
+  ec2:
+    key-name: key_name
+    identity-file: /path/to/.ssh/key.pem
+    instance-type: m3.medium
+    region: us-east-1
+    ami: ami-08111162
+    user: ec2-user
 ```
 
 With a config file like that, you can now launch a cluster with just this:


### PR DESCRIPTION
This PR makes the following changes:
* Fixes a bug in the documentation which does not mention that "providers" key above "ec2"

I tested this PR by...
* Running the following command `flintrock --config config.yml launch test` and it worked.

Fixes #116.