### PR TITLE
Add option to download Hadoop from a custom URL

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -5,6 +5,9 @@ services:
     # git-repository:  # optional; defaults to https://github.com/apache/spark
   hdfs:
     version: 2.7.2
+    # download-source: # optional; defaults to
+    # http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json
+    # and must contain a {v} template corresponding to the version
 
 provider: ec2
 

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -5,9 +5,9 @@ services:
     # git-repository:  # optional; defaults to https://github.com/apache/spark
   hdfs:
     version: 2.7.2
-    # download-source: # optional; defaults to
-    # http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json
-    # and must contain a {v} template corresponding to the version
+    # optional; defaults to download from a dynamically selected Apache mirror
+    # must contain a {v} template corresponding to the version; must be a .tar.gz file
+    # download-source: "https://www.example.com/files/hadoop/{v}/hadoop-{v}.tar.gz"
 
 provider: ec2
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -179,6 +179,10 @@ def cli(cli_context, config, provider):
 @click.option('--num-slaves', type=int, required=True)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
 @click.option('--hdfs-version')
+@click.option('--hdfs-download-source',
+              help="Custom URL to download hadoop from.",
+              default='http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json',
+              show_default=True)
 @click.option('--install-spark/--no-install-spark', default=True)
 @click.option('--spark-version',
               help="Spark release version to install.")
@@ -218,6 +222,7 @@ def launch(
         num_slaves,
         install_hdfs,
         hdfs_version,
+        hdfs_download_source,
         install_spark,
         spark_version,
         spark_git_commit,
@@ -276,13 +281,11 @@ def launch(
     #      https://github.com/mitchellh/packer/issues/1935#issuecomment-111235752
     option_requires(
         option='--ec2-vpc-id',
-        requires_all=[
-            '--ec2-subnet-id'
-        ],
+        requires_all=['--ec2-subnet-id'],
         scope=locals())
 
     if install_hdfs:
-        hdfs = HDFS(version=hdfs_version)
+        hdfs = HDFS(version=hdfs_version, download_source=hdfs_download_source)
         services += [hdfs]
     if install_spark:
         if spark_version:

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -180,7 +180,7 @@ def cli(cli_context, config, provider):
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
 @click.option('--hdfs-version')
 @click.option('--hdfs-download-source',
-              help="Custom URL to download hadoop from.",
+              help="URL to download Hadoop from.",
               default='http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json',
               show_default=True)
 @click.option('--install-spark/--no-install-spark', default=True)

--- a/flintrock/scripts/download-hadoop.py
+++ b/flintrock/scripts/download-hadoop.py
@@ -1,11 +1,10 @@
 """
-Download Hadoop from the best available Apache mirror.
+Download Hadoop from the best available Apache mirror or a custom location.
 """
 
 from __future__ import print_function
 
 import json
-import os
 import sys
 import subprocess
 
@@ -18,27 +17,22 @@ else:
 
 if __name__ == '__main__':
     hadoop_version = sys.argv[1]
-    custom_mirror_url = sys.argv[2]
-
-    if custom_mirror_url:
-        mirror_url = custom_mirror_url.format(v=hadoop_version)
-    else:
-        mirror_url = "http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json"\
-            .format(v=hadoop_version)
+    mirror_url = sys.argv[2].format(v=hadoop_version)
+    default_mirror_url = \
+        'http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json'\
+        .format(v=hadoop_version)
 
     tries = 0
     while tries < 3:
-        if custom_mirror_url:
-            print("Downloading file at:", mirror_url)
-            file_name = os.path.basename(mirror_url)
-            file_path, _ = urlretrieve(url=mirror_url, filename=file_name)
-        else:
+        if mirror_url == default_mirror_url:
             mirror_info = json.loads(urlopen(mirror_url).read().decode('utf-8'))
             file_url = mirror_info['preferred'] + mirror_info['path_info']
-            file_name = os.path.basename(mirror_info['path_info'])
-            print("Downloading file at:", file_url)
-            file_path, _ = urlretrieve(url=file_url, filename=file_name)
+        else:
+            file_url = mirror_url
 
+        print("Downloading file at:", file_url)
+        file_path, _ = \
+            urlretrieve(url=file_url, filename="hadoop-{v}.tar.gz".format(v=hadoop_version))
         ret = subprocess.call(['gzip', '--test', file_path])
 
         if ret == 0:

--- a/flintrock/scripts/download-hadoop.py
+++ b/flintrock/scripts/download-hadoop.py
@@ -17,12 +17,18 @@ else:
 
 
 if __name__ == '__main__':
-    hadoop_version = sys.argv[1]
-    apache_mirror_url = "http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json".format(v=hadoop_version)
+    arg_names = ['hadoop_version', 'custom_mirror_url']
+    args = dict(zip(arg_names, sys.argv))
+
+    if 'custom_mirror_url' in args.keys:
+        mirror_url = args['custom_mirror_url'].format(v=args['hadoop_version'])
+    else:
+        mirror_url = "http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json"\
+            .format(v=args['hadoop_version'])
 
     tries = 0
     while tries < 3:
-        mirror_info = json.loads(urlopen(apache_mirror_url).read().decode('utf-8'))
+        mirror_info = json.loads(urlopen(mirror_url).read().decode('utf-8'))
         file_url = mirror_info['preferred'] + mirror_info['path_info']
         file_name = os.path.basename(mirror_info['path_info'])
         print('Downloading file at:', file_url)

--- a/flintrock/scripts/download-hadoop.py
+++ b/flintrock/scripts/download-hadoop.py
@@ -17,23 +17,28 @@ else:
 
 
 if __name__ == '__main__':
-    arg_names = ['hadoop_version', 'custom_mirror_url']
-    args = dict(zip(arg_names, sys.argv))
+    hadoop_version = sys.argv[1]
+    custom_mirror_url = sys.argv[2]
 
-    if 'custom_mirror_url' in args.keys:
-        mirror_url = args['custom_mirror_url'].format(v=args['hadoop_version'])
+    if custom_mirror_url:
+        mirror_url = custom_mirror_url.format(v=hadoop_version)
     else:
         mirror_url = "http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json"\
-            .format(v=args['hadoop_version'])
+            .format(v=hadoop_version)
 
     tries = 0
     while tries < 3:
-        mirror_info = json.loads(urlopen(mirror_url).read().decode('utf-8'))
-        file_url = mirror_info['preferred'] + mirror_info['path_info']
-        file_name = os.path.basename(mirror_info['path_info'])
-        print('Downloading file at:', file_url)
+        if custom_mirror_url:
+            print("Downloading file at:", mirror_url)
+            file_name = os.path.basename(mirror_url)
+            file_path, _ = urlretrieve(url=mirror_url, filename=file_name)
+        else:
+            mirror_info = json.loads(urlopen(mirror_url).read().decode('utf-8'))
+            file_url = mirror_info['preferred'] + mirror_info['path_info']
+            file_name = os.path.basename(mirror_info['path_info'])
+            print("Downloading file at:", file_url)
+            file_path, _ = urlretrieve(url=file_url, filename=file_name)
 
-        file_path, _ = urlretrieve(url=file_url, filename=file_name)
         ret = subprocess.call(['gzip', '--test', file_path])
 
         if ret == 0:

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -108,9 +108,10 @@ class FlintrockService:
 
 
 class HDFS(FlintrockService):
-    def __init__(self, version):
+    def __init__(self, version, download_source):
         self.version = version
-        self.manifest = {'version': version}
+        self.download_source = download_source
+        self.manifest = {'version': version, 'download_source': download_source}
 
     def install(
             self,
@@ -129,14 +130,14 @@ class HDFS(FlintrockService):
             command="""
                 set -e
 
-                python /tmp/download-hadoop.py "{version}"
+                python /tmp/download-hadoop.py "{version}" "{download_source}"
 
                 mkdir "hadoop"
                 mkdir "hadoop/conf"
 
                 tar xzf "hadoop-{version}.tar.gz" -C "hadoop" --strip-components=1
                 rm "hadoop-{version}.tar.gz"
-            """.format(version=self.version))
+            """.format(version=self.version, download_source=self.download_source))
 
     def configure(
             self,


### PR DESCRIPTION
This PR makes the following changes:
* add an option to specify your own mirror to download hadoop from

I did some manual tests:
  - no `download_source`
  - working `download_source`
  - faulty `download_source`

Fixes #71.
Supersedes / Fixes #109.