### PR TITLE
Correct default values for install-{spark,hdfs} in the config template

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -32,5 +32,5 @@ providers:
 
 launch:
   num-slaves: 1
-  # install-hdfs: True
-  # install-spark: False
+  # install-spark: True
+  # install-hdfs: False


### PR DESCRIPTION
I noticed that the values in the config template weren't reflecting the default values for install-{spark,hdfs}, this pr aims to fix that.

