### PR TITLE
Add option to download Spark from a custom URL

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -3,13 +3,16 @@ services:
     version: 1.6.1
     # git-commit: latest  # if not 'latest', provide a full commit SHA; e.g. d6dc12ef0146ae409834c78737c116050961f350
     # git-repository:  # optional; defaults to https://github.com/apache/spark
-    # optional; defaults to download from a dynamically selected Apache mirror
-    # must contain a {v} template corresponding to the version; must be a .tar.gz file
+    # optional; defaults to download from from the official Spark S3 bucket
+    #   - must contain a {v} template corresponding to the version
+    #   - Spark must be pre-built
+    #   - must be a tar.gz file
     # download-source: "https://www.example.com/files/spark/{v}/spark-{v}.tar.gz"
   hdfs:
     version: 2.7.2
     # optional; defaults to download from a dynamically selected Apache mirror
-    # must contain a {v} template corresponding to the version; must be a .tar.gz file
+    #   - must contain a {v} template corresponding to the version
+    #   - must be a .tar.gz file
     # download-source: "https://www.example.com/files/hadoop/{v}/hadoop-{v}.tar.gz"
 
 provider: ec2

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -3,6 +3,9 @@ services:
     version: 1.6.1
     # git-commit: latest  # if not 'latest', provide a full commit SHA; e.g. d6dc12ef0146ae409834c78737c116050961f350
     # git-repository:  # optional; defaults to https://github.com/apache/spark
+    # optional; defaults to download from a dynamically selected Apache mirror
+    # must contain a {v} template corresponding to the version; must be a .tar.gz file
+    # download-source: "https://www.example.com/files/spark/{v}/spark-{v}.tar.gz"
   hdfs:
     version: 2.7.2
     # optional; defaults to download from a dynamically selected Apache mirror

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -194,6 +194,10 @@ def cli(cli_context, config, provider):
               help="Git repository to clone Spark from.",
               default='https://github.com/apache/spark',
               show_default=True)
+@click.option('--spark-download-source',
+              help="URL to download Spark from.",
+              default='https://s3.amazonaws.com/spark-related-packages/spark-{v}-bin-hadoop2.6.tgz',
+              show_default=True)
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-key-name')
 @click.option('--ec2-identity-file',
@@ -227,6 +231,7 @@ def launch(
         spark_version,
         spark_git_commit,
         spark_git_repository,
+        spark_download_source,
         assume_yes,
         ec2_key_name,
         ec2_identity_file,
@@ -289,7 +294,7 @@ def launch(
         services += [hdfs]
     if install_spark:
         if spark_version:
-            spark = Spark(version=spark_version)
+            spark = Spark(version=spark_version, download_source=spark_download_source)
         elif spark_git_commit:
             print(
                 "Warning: Building Spark takes a long time. "

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -186,6 +186,10 @@ def cli(cli_context, config, provider):
 @click.option('--install-spark/--no-install-spark', default=True)
 @click.option('--spark-version',
               help="Spark release version to install.")
+@click.option('--spark-download-source',
+              help="URL to download a release of Spark from.",
+              default='https://s3.amazonaws.com/spark-related-packages/spark-{v}-bin-hadoop2.6.tgz',
+              show_default=True)
 @click.option('--spark-git-commit',
               help="Git commit to build Spark from. "
                    "Set to 'latest' to build Spark from the latest commit on the "
@@ -193,10 +197,6 @@ def cli(cli_context, config, provider):
 @click.option('--spark-git-repository',
               help="Git repository to clone Spark from.",
               default='https://github.com/apache/spark',
-              show_default=True)
-@click.option('--spark-download-source',
-              help="URL to download Spark from.",
-              default='https://s3.amazonaws.com/spark-related-packages/spark-{v}-bin-hadoop2.6.tgz',
               show_default=True)
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-key-name')

--- a/flintrock/scripts/install-spark.sh
+++ b/flintrock/scripts/install-spark.sh
@@ -2,14 +2,12 @@
 
 set -e
 
-spark_version="$1"
-distribution="$2"
+url="$1"
 
 echo "Installing Spark..."
-echo "  version: ${spark_version}"
-echo "  distribution: ${distribution}"
+echo "  from: ${url}"
 
-file="spark-${spark_version}-bin-${distribution}.tgz"
+file=$(basename ${url})
 
 # S3 is generally reliable, but sometimes when launching really large
 # clusters it can hiccup on us, in which case we'll need to retry the
@@ -17,7 +15,7 @@ file="spark-${spark_version}-bin-${distribution}.tgz"
 set +e
 tries=1
 while true; do
-    curl --remote-name "https://s3.amazonaws.com/spark-related-packages/${file}"
+    curl --remote-name "${url}"
     curl_ret=$?
 
     if ((curl_ret == 0)); then

--- a/flintrock/scripts/install-spark.sh
+++ b/flintrock/scripts/install-spark.sh
@@ -7,7 +7,7 @@ url="$1"
 echo "Installing Spark..."
 echo "  from: ${url}"
 
-file=$(basename ${url})
+file="$(basename ${url})"
 
 # S3 is generally reliable, but sometimes when launching really large
 # clusters it can hiccup on us, in which case we'll need to retry the


### PR DESCRIPTION
This PR adds a `download_source` to the Spark service as has been done in #118.

I created clusters with both with and without a `download_source` to test the new feature.

Fixes #101, fixes #88.
Closes #104.
