### PR TITLE
Add running scripts before and after cluster provision

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -14,6 +14,13 @@ services:
     #   - must contain a {v} template corresponding to the version
     #   - must be a .tar.gz file
     # download-source: "https://www.example.com/files/hadoop/{v}/hadoop-{v}.tar.gz"
+  # optional; run scripts prior or posterior to cluster provision
+  # preinstall:
+  #   master: path/to/script.sh
+  #   slave: path/to/script.sh
+  # postinstall:
+  #   master: path/to/script.sh
+  #   slave: path/to/script.sh
 
 provider: ec2
 

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -347,7 +347,7 @@ def _run_asynchronously(*, partial_func: functools.partial, hosts: list):
 
     This function assumes that partial_func accepts `host` as a keyword argument.
     """
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     executor = concurrent.futures.ThreadPoolExecutor(len(hosts))
 
     tasks = []

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -421,6 +421,14 @@ def provision_cluster(
                 ssh_client=master_ssh_client,
                 cluster=cluster)
 
+    partial_func = functools.partial(
+        configure_slave,
+        services=services,
+        user=user,
+        identity_file=identity_file,
+        cluster=cluster)
+    _run_asynchronously(partial_func=partial_func, hosts=cluster.slave_ips)
+
     # NOTE: We sleep here so that the slave services have time to come up.
     #       If we refactor stuff to have a start_slave() that blocks until
     #       the slave is fully up, then we won't need this sleep anymore.
@@ -510,6 +518,29 @@ def provision_node(
                 ssh_client=client,
                 cluster=cluster)
             service.configure(
+                ssh_client=client,
+                cluster=cluster)
+
+
+def configure_slave(
+        *,
+        services: list,
+        user: str,
+        host: str,
+        identity_file: str,
+        cluster: FlintrockCluster):
+    """
+    This method is meant to be called asynchronously.
+    """
+    client = get_ssh_client(
+        user=user,
+        host=host,
+        identity_file=identity_file,
+        wait=True)
+
+    with client:
+        for service in services:
+            service.configure_slave(
                 ssh_client=client,
                 cluster=cluster)
 
@@ -619,4 +650,4 @@ def copy_file_node(
 # core.py and services.py. I've thought about how to remove this circular dependency,
 # but for now this seems like what we need to go with.
 # Flintrock modules
-from .services import HDFS, Spark  # Used by start_cluster()
+from .services import HDFS, Spark, UserScript  # Used by start_cluster()

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -184,6 +184,12 @@ class HDFS(FlintrockService):
                 ./hadoop/sbin/start-dfs.sh
             """)
 
+    def configure_slave(
+            self,
+            ssh_client: paramiko.client.SSHClient,
+            cluster: FlintrockCluster):
+        pass
+
     def health_check(self, master_host: str):
         # This info is not helpful as a detailed health check, but it gives us
         # an up / not up signal.
@@ -340,6 +346,12 @@ class Spark(FlintrockService):
             """.format(
                 m=shlex.quote(cluster.master_host)))
 
+    def configure_slave(
+            self,
+            ssh_client: paramiko.client.SSHClient,
+            cluster: FlintrockCluster):
+        pass
+
     def health_check(self, master_host: str):
         spark_master_ui = 'http://{m}:8080/json/'.format(m=master_host)
 
@@ -366,3 +378,64 @@ class Spark(FlintrockService):
                 workers=len(spark_ui_info['workers']),
                 cores=spark_ui_info['cores'],
                 memory=spark_ui_info['memory'] / 1024)))
+
+
+class UserScript(FlintrockService):
+    def __init__(self, master_scripts, slave_scripts):
+        self.master_scripts = master_scripts
+        self.slave_scripts = slave_scripts
+        # TODO(sybaek): Implement manifest
+        self.manifest = {"master_scripts": master_scripts, "slave_scripts": slave_scripts}
+
+    def _copy_and_run_scripts(self, ssh_client, scripts):
+        for script in scripts:
+            host = ssh_client.get_transport().getpeername()[0]
+            print("[{h}] Running script '{s}'...".format(h=host, s=script))
+            remotepath = os.path.join('/tmp/', os.path.basename(script))
+            with ssh_client.open_sftp() as sftp:
+                sftp.put(
+                    localpath=script,
+                    remotepath=remotepath)
+                sftp.chmod(path=remotepath, mode=0o755)
+            ssh_check_output(
+                client=ssh_client,
+                command="""
+                    set -e
+                    {remotepath}
+                    rm -f {remotepath}
+                """.format(remotepath=remotepath))
+
+    def install(
+            self,
+            ssh_client: paramiko.client.SSHClient,
+            cluster: FlintrockCluster):
+        pass
+
+    def configure(
+            self,
+            ssh_client: paramiko.client.SSHClient,
+            cluster: FlintrockCluster):
+        pass
+
+    def configure_master(
+            self,
+            ssh_client: paramiko.client.SSHClient,
+            cluster: FlintrockCluster):
+        if self.master_scripts:
+            host = ssh_client.get_transport().getpeername()[0]
+            print("[{h}] Running scripts on master...".format(h=host))
+
+            self._copy_and_run_scripts(ssh_client, self.master_scripts)
+
+    def configure_slave(
+            self,
+            ssh_client: paramiko.client.SSHClient,
+            cluster: FlintrockCluster):
+        if self.slave_scripts:
+            host = ssh_client.get_transport().getpeername()[0]
+            print("[{h}] Running scripts on slave...".format(h=host))
+
+            self._copy_and_run_scripts(ssh_client, self.slave_scripts)
+
+    def health_check(self, master_host: str):
+        pass


### PR DESCRIPTION
This PR makes the following changes:
* Fix `_run_asyncronously` function not working second time
* Add flags like `--preinstall-master` to enable users to run custom shell scripts before and after cluster provision

I tested this PR by deploying cluster to AWS

The typical use-case for this functionality would be like below:
 * Replace Java 1.7 to Java 1.8. This can only be done **BEFORE** Spark installation (BTW, Spark 2.0 depreciates Java 1.7 support)
 * Install custom Python package like Anaconda for use with PySpark
 * Perform special filesystem operations (like RAID, mounting)