### PR TITLE
Migrate from pep8 -> pycodestyle

### DIFF
--- a/requirements/developer.pip
+++ b/requirements/developer.pip
@@ -1,5 +1,5 @@
 -r user.pip
-pep8 >= 1.7.0
+pycodestyle >= 2.0.0
 pytest >= 2.9.2
 pytest-cov >= 2.3.0
 # PyYAML  # requirement already covered by setup.py

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -2,7 +2,7 @@ import compileall
 import os
 
 # External modules
-import pep8
+import pycodestyle
 import yaml
 
 FLINTROCK_ROOT_DIR = (
@@ -31,8 +31,8 @@ def test_code_compiles():
         assert result == 1
 
 
-def test_pep8_compliance():
-    style = pep8.StyleGuide(
+def test_style():
+    style = pycodestyle.StyleGuide(
         config_file=os.path.join(FLINTROCK_ROOT_DIR, 'tox.ini'))
     result = style.check_files(TEST_PATHS)
     assert result.total_errors == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+# [pycodestyle]
+# Need to stick to [pep8] for now due to bug in pycodestyle.
+# See: https://github.com/PyCQA/pycodestyle/issues/550
 [pep8]
 max-line-length=100
 ignore=E501,E402


### PR DESCRIPTION
The project got [renamed](https://github.com/PyCQA/pycodestyle/blob/39e57186620c8d8c87eaf4b0f3b00ff90b716f7e/CHANGES.txt#L16-L22).