### PR TITLE
Fix assume_yes not existing in _create_instances

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -229,7 +229,8 @@ class EC2Cluster(FlintrockCluster):
             user: str,
             identity_file: str,
             num_slaves: int,
-            spot_price: float):
+            spot_price: float,
+            assume_yes: bool):
         security_group_ids = [
             group['GroupId']
             for group in self.master_instance.security_groups]
@@ -258,6 +259,7 @@ class EC2Cluster(FlintrockCluster):
             region=self.region,
             spot_price=spot_price,
             ami=self.master_instance.image_id,
+            assume_yes=assume_yes,
             key_name=self.master_instance.key_name,
             instance_type=self.master_instance.instance_type,
             block_device_mappings=block_device_mappings,
@@ -637,6 +639,7 @@ def _create_instances(
         region,
         spot_price,
         ami,
+        assume_yes,
         key_name,
         instance_type,
         block_device_mappings,
@@ -865,6 +868,7 @@ def launch(
         region=region,
         spot_price=spot_price,
         ami=ami,
+        assume_yes=assume_yes,
         key_name=key_name,
         instance_type=instance_type,
         block_device_mappings=block_device_mappings,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -596,6 +596,7 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
               help="Path to SSH .pem file for accessing nodes.")
 @click.option('--ec2-user')
 @click.option('--ec2-spot-price', type=float)
+@click.option('--assume-yes/--no-assume-yes', default=False)
 @click.pass_context
 def add_slaves(
         cli_context,
@@ -605,7 +606,8 @@ def add_slaves(
         ec2_vpc_id,
         ec2_identity_file,
         ec2_user,
-        ec2_spot_price):
+        ec2_spot_price,
+        assume_yes):
     """
     Add slaves to an existing cluster.
 
@@ -653,6 +655,7 @@ def add_slaves(
             user=user,
             identity_file=identity_file,
             num_slaves=num_slaves,
+            assume_yes=assume_yes,
             **provider_options)
 
 


### PR DESCRIPTION
I've encountered an error while doing test:

```
$ python3 -m flintrock --config config.yaml launch serialx-test
Requesting 3 spot instances at a max price of $0.311...
0 of 3 instances granted. Waiting...
0 of 3 instances granted. Waiting...
0 of 3 instances granted. Waiting...
0 of 3 instances granted. Waiting...
0 of 3 instances granted. Waiting...
0 of 3 instances granted. Waiting...
^CThere was a problem with the launch. Cleaning up...
Canceling spot instance requests...
Traceback (most recent call last):
  File "/Users/serialx/workspace/flintrock/flintrock/ec2.py", line 685, in _create_instances
    time.sleep(30)
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/serialx/workspace/flintrock/flintrock/__main__.py", line 8, in <module>
    sys.exit(main())
  File "/Users/serialx/workspace/flintrock/flintrock/flintrock.py", line 1034, in main
    cli(obj={})
  File "/Users/serialx/.virtualenvs/flintrock/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/serialx/.virtualenvs/flintrock/lib/python3.5/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/serialx/.virtualenvs/flintrock/lib/python3.5/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/serialx/.virtualenvs/flintrock/lib/python3.5/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/serialx/.virtualenvs/flintrock/lib/python3.5/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/serialx/.virtualenvs/flintrock/lib/python3.5/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/serialx/workspace/flintrock/flintrock/flintrock.py", line 339, in launch
    instance_initiated_shutdown_behavior=ec2_instance_initiated_shutdown_behavior)
  File "/Users/serialx/workspace/flintrock/flintrock/ec2.py", line 46, in wrapper
    res = func(*args, **kwargs)
  File "/Users/serialx/workspace/flintrock/flintrock/ec2.py", line 878, in launch
    instance_initiated_shutdown_behavior=instance_initiated_shutdown_behavior)
  File "/Users/serialx/workspace/flintrock/flintrock/ec2.py", line 759, in _create_instances
    if not assume_yes:
NameError: name 'assume_yes' is not defined
```

This is an attempt to fix it.