### PR TITLE
Add --ec2-user-data option to launch command

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -39,6 +39,7 @@ providers:
     tenancy: default  # default | dedicated
     ebs-optimized: no  # yes | no
     instance-initiated-shutdown-behavior: terminate  # terminate | stop
+    # user-data: /path/to/userdata/script
 
 launch:
   num-slaves: 1

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -668,6 +668,7 @@ def _create_instances(
 
     try:
         if spot_price:
+            user_data = base64.b64encode(user_data.encode('utf-8')).decode()
             print("Requesting {c} spot instances at a max price of ${p}...".format(
                 c=num_instances, p=spot_price))
             client = ec2.meta.client

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -665,6 +665,7 @@ def _create_instances(
 
     cluster_instances = []
     spot_requests = []
+    user_data = user_data.read()
 
     try:
         if spot_price:
@@ -877,9 +878,6 @@ def launch(
 
     num_instances = num_slaves + 1
 
-    if user_data != '':
-        user_data = _get_user_data(user_data)
-
     cluster_instances = _create_instances(
         num_instances=num_instances,
         region=region,
@@ -1050,14 +1048,3 @@ def _compose_cluster(*, name: str, region: str, vpc_id: str, instances: list) ->
         slave_instances=slave_instances)
 
     return cluster
-
-
-def _get_user_data(user_data: str) -> str:
-    """
-    Get the contents of the userdata script from the given path.
-    """
-    if os.path.exists(user_data):
-        contents = open(user_data).read()
-        return contents
-    else:
-        raise Exception("Could not find the userdata script")

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -665,7 +665,6 @@ def _create_instances(
 
     cluster_instances = []
     spot_requests = []
-    user_data = user_data.read()
 
     try:
         if spot_price:
@@ -877,6 +876,10 @@ def launch(
         instance_profile_arn = ''
 
     num_instances = num_slaves + 1
+    if user_data is not None:
+        user_data = user_data.read()
+    else:
+        user_data = ''
 
     cluster_instances = _create_instances(
         num_instances=num_instances,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -226,8 +226,9 @@ def cli(cli_context, config, provider):
 @click.option('--ec2-ebs-optimized/--no-ec2-ebs-optimized', default=False)
 @click.option('--ec2-instance-initiated-shutdown-behavior', default='stop',
               type=click.Choice(['stop', 'terminate']))
-@click.option('--ec2-user-data', default='',
-              help="Path to userdata script file for accessing nodes.")
+@click.option('--ec2-user-data',
+              type=click.File(mode='r', encoding='utf-8'),
+              help="Path to EC2 user data script that will run on instance launch.")
 @click.pass_context
 def launch(
         cli_context,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -226,6 +226,8 @@ def cli(cli_context, config, provider):
 @click.option('--ec2-ebs-optimized/--no-ec2-ebs-optimized', default=False)
 @click.option('--ec2-instance-initiated-shutdown-behavior', default='stop',
               type=click.Choice(['stop', 'terminate']))
+@click.option('--ec2-user-data', default='',
+              help="Path to userdata script file for accessing nodes.")
 @click.pass_context
 def launch(
         cli_context,
@@ -255,7 +257,8 @@ def launch(
         ec2_placement_group,
         ec2_tenancy,
         ec2_ebs_optimized,
-        ec2_instance_initiated_shutdown_behavior):
+        ec2_instance_initiated_shutdown_behavior,
+        ec2_user_data):
     """
     Launch a new cluster.
     """
@@ -336,7 +339,8 @@ def launch(
             placement_group=ec2_placement_group,
             tenancy=ec2_tenancy,
             ebs_optimized=ec2_ebs_optimized,
-            instance_initiated_shutdown_behavior=ec2_instance_initiated_shutdown_behavior)
+            instance_initiated_shutdown_behavior=ec2_instance_initiated_shutdown_behavior,
+            user_data=ec2_user_data)
     else:
         raise UnsupportedProviderError(provider)
 


### PR DESCRIPTION
This PR adds `--ec2-user-data` option to launch command.
This flag can help users create `UserData` defined instances. 
`--ec2-user-data` requires the path of `UserData` script file, and it could support long and complex script under 16KB.[1]

In case of increasing the number of slave instances, new slave instances are going to have the same `userdata` from the master instance.

I tested this PR by deploying cluster to AWS.


This PR is related to [#142](https://github.com/nchammas/flintrock/pull/142).
[1]: [Configuring Instances with User Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)