### PR TITLE
Upgrade to Paramiko 2.0.2

### DIFF
--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -76,8 +76,8 @@ def get_ssh_client(
             break
         except socket.timeout as e:
             time.sleep(5)
-        except socket.error as e:
-            if e.errno != errno.ECONNREFUSED:
+        except paramiko.ssh_exception.NoValidConnectionsError as e:
+            if any(error.errno != errno.ECONNREFUSED for error in e.errors.values()):
                 raise
             time.sleep(5)
         # We get this exception during startup with CentOS but not Amazon Linux,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
         'boto3 == 1.4.1',
         'botocore == 1.4.67',
         'click == 6.6',
-        'paramiko == 1.15.4',
+        'paramiko == 2.0.2',
         'PyYAML == 3.12',
         # This is to ensure that PyInstaller works. dateutil is an
         # indirect dependency of Flintrock, and PyInstaller chokes on


### PR DESCRIPTION
I’ve been avoiding this for a while due to [a minor backwards-incompatible change](https://github.com/paramiko/paramiko/issues/769), but I finally got around to it.

This upgrade should have no user-facing impact, but under the sheets Paramiko is now using the new Cryptography library (as opposed to PyCrypto).

This may impact our PyInstaller packaging on Linux. Let’s see if Travis has any issues running our packaging test.