### PR TITLE
Resolve #163. Allow more ports for SparkUI.

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -544,7 +544,7 @@ def get_or_create_flintrock_security_groups(
         SecurityGroupRule(
             ip_protocol='tcp',
             from_port=4040,
-            to_port=4040,
+            to_port=4050,
             cidr_ip=flintrock_client_cidr,
             src_group=None),
         SecurityGroupRule(


### PR DESCRIPTION
Resolves #163.  When there is more than one Spark applications running, additional ports
are allocated for SparkUI.  [Default port are 4040][1] in the SparkUI
code.  But, [when the default port is already allocated, it increments
the port until bind is successful][2].

[1]: https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/ui/SparkUI.scala#L137
[2]: https://github.com/apache/spark/blob/70a5db7bbd192a4bc68bcfdc475ab221adf2fcdd/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala#L266