### PR TITLE
Fix for spark 1.6.x

### DIFF
--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -8,6 +8,9 @@ export SPARK_WORKER_CORES="$(nproc)"
 
 export SPARK_MASTER_HOST="{master_host}"
 
+# Needed for spark 1.6.x
+export SPARK_MASTER_IP="{master_ip}"
+
 # TODO: Make this dependent on HDFS install.
 export HADOOP_CONF_DIR="/home/$(logname)/hadoop/conf"
 


### PR DESCRIPTION
This PR makes the following changes:
* Define `SPARK_MASTER_IP`, as it is needed for Spark 1.6.x. 

I tested this PR using command `flintrock launch` with Spark 1.6.3.

Scripts "sbin/start-master.sh" and "sbin/start-slaves.sh" in 1.6.x use `SPARK_MASTER_IP`. This has been changed by the following PR in Spark 2.0.0 : https://github.com/apache/spark/pull/13543/files

The associated JIRA is https://issues.apache.org/jira/browse/SPARK-15806