### PR TITLE
Fix the environment passed to subprocess calls when Flintrock is packaged with PyInstaller

### DIFF
--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 import paramiko
 
 # Flintrock modules
+from .util import get_subprocess_env
 from .exceptions import SSHError
 
 SSHKeyPair = namedtuple('KeyPair', ['public', 'private'])
@@ -21,13 +22,17 @@ def generate_ssh_key_pair() -> SSHKeyPair:
     communication.
     """
     with tempfile.TemporaryDirectory() as tempdir:
-        subprocess.check_call([
-            'ssh-keygen',
-            '-q',
-            '-t', 'rsa',
-            '-N', '',
-            '-f', os.path.join(tempdir, 'flintrock_rsa'),
-            '-C', 'flintrock'])
+        subprocess.check_call(
+            [
+                'ssh-keygen',
+                '-q',
+                '-t', 'rsa',
+                '-N', '',
+                '-f', os.path.join(tempdir, 'flintrock_rsa'),
+                '-C', 'flintrock',
+            ],
+            env=get_subprocess_env(),
+        )
 
         with open(file=os.path.join(tempdir, 'flintrock_rsa')) as private_key_file:
             private_key = private_key_file.read()
@@ -124,8 +129,12 @@ def ssh(*, user: str, host: str, identity_file: str):
     """
     SSH into a host for interactive use.
     """
-    ret = subprocess.call([
-        'ssh',
-        '-o', 'StrictHostKeyChecking=no',
-        '-i', identity_file,
-        '{u}@{h}'.format(u=user, h=host)])
+    ret = subprocess.call(
+        [
+            'ssh',
+            '-o', 'StrictHostKeyChecking=no',
+            '-i', identity_file,
+            '{u}@{h}'.format(u=user, h=host),
+        ],
+        env=get_subprocess_env(),
+    )

--- a/flintrock/util.py
+++ b/flintrock/util.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+FROZEN = getattr(sys, 'frozen', False)
+
+
+def get_subprocess_env() -> dict:
+    """
+    Get the environment we want to use when making subprocess calls.
+    This takes care of details that affect subprocess calls made from
+    PyInstaller-packaged versions of Flintrock.
+
+    For more information see: https://github.com/pyinstaller/pyinstaller/blob/develop/doc/runtime-information.rst#ld_library_path--libpath-considerations
+    """
+    env = dict(os.environ)
+    if FROZEN and env.get('LD_LIBRARY_PATH_ORIG') is not None:
+        env['LD_LIBRARY_PATH'] = env['LD_LIBRARY_PATH_ORIG']
+    return env

--- a/flintrock/util.py
+++ b/flintrock/util.py
@@ -13,6 +13,6 @@ def get_subprocess_env() -> dict:
     For more information see: https://github.com/pyinstaller/pyinstaller/blob/develop/doc/runtime-information.rst#ld_library_path--libpath-considerations
     """
     env = dict(os.environ)
-    if FROZEN and env.get('LD_LIBRARY_PATH_ORIG') is not None:
-        env['LD_LIBRARY_PATH'] = env['LD_LIBRARY_PATH_ORIG']
+    if FROZEN:
+        env['LD_LIBRARY_PATH'] = env.get('LD_LIBRARY_PATH_ORIG', '')
     return env


### PR DESCRIPTION
Fixes #158.