### PR TITLE
Added debug messages and use the logging framework for stdout

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -49,3 +49,5 @@ launch:
   num-slaves: 1
   # install-hdfs: True
   # install-spark: False
+
+debug: false

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -6,6 +6,7 @@ import posixpath
 import shlex
 import sys
 import time
+import logging
 from concurrent.futures import FIRST_EXCEPTION
 
 # External modules
@@ -23,6 +24,9 @@ else:
     THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
 SCRIPTS_DIR = os.path.join(THIS_DIR, 'scripts')
+
+
+logger = logging.getLogger('flintrock.core')
 
 
 class StorageDirs:
@@ -495,7 +499,7 @@ def ensure_java8(client: paramiko.client.SSHClient):
     java_major_version = get_java_major_version(client)
 
     if not java_major_version or java_major_version < (1, 8):
-        print("[{h}] Installing Java 1.8...".format(h=host))
+        logger.info("[{h}] Installing Java 1.8...".format(h=host))
 
         ssh_check_output(
             client=client,
@@ -548,7 +552,7 @@ def setup_node(
             localpath=os.path.join(SCRIPTS_DIR, 'setup-ephemeral-storage.py'),
             remotepath='/tmp/setup-ephemeral-storage.py')
 
-    print("[{h}] Configuring ephemeral storage...".format(h=host))
+    logger.info("[{h}] Configuring ephemeral storage...".format(h=host))
     # TODO: Print some kind of warning if storage is large, since formatting
     #       will take several minutes (~4 minutes for 2TB).
     storage_dirs_raw = ssh_check_output(
@@ -771,7 +775,7 @@ def run_command_node(*, user: str, host: str, identity_file: str, command: tuple
         host=host,
         identity_file=identity_file)
 
-    print("[{h}] Running command...".format(h=host))
+    logger.info("[{h}] Running command...".format(h=host))
 
     command_str = ' '.join(command)
 
@@ -780,7 +784,7 @@ def run_command_node(*, user: str, host: str, identity_file: str, command: tuple
             client=ssh_client,
             command=command_str)
 
-    print("[{h}] Command complete.".format(h=host))
+    logger.info("[{h}] Command complete.".format(h=host))
 
 
 def copy_file_node(
@@ -815,11 +819,11 @@ def copy_file_node(
             raise Exception("Remote directory does not exist: {d}".format(d=remote_dir))
 
         with ssh_client.open_sftp() as sftp:
-            print("[{h}] Copying file...".format(h=host))
+            logger.info("[{h}] Copying file...".format(h=host))
 
             sftp.put(localpath=local_path, remotepath=remote_path)
 
-            print("[{h}] Copy complete.".format(h=host))
+            logger.info("[{h}] Copy complete.".format(h=host))
 
 
 # This is necessary down here since we have a circular import dependency between

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -5,6 +5,7 @@ import time
 import urllib.request
 import base64
 import os
+import logging
 from collections import namedtuple
 from datetime import datetime
 
@@ -25,6 +26,9 @@ from .exceptions import (
     NothingToDo,
 )
 from .ssh import generate_ssh_key_pair
+
+
+logger = logging.getLogger('flintrock.ec2')
 
 
 class NoDefaultVPC(Error):
@@ -49,7 +53,7 @@ def timeit(func):
         start = datetime.now().replace(microsecond=0)
         res = func(*args, **kwargs)
         end = datetime.now().replace(microsecond=0)
-        print("{f} finished in {t}.".format(f=func.__name__, t=(end - start)))
+        logger.info("{f} finished in {t}.".format(f=func.__name__, t=(end - start)))
         return res
     return wrapper
 
@@ -121,6 +125,12 @@ class EC2Cluster(FlintrockCluster):
         ec2 = boto3.resource(service_name='ec2', region_name=self.region)
 
         while any([i.state['Name'] != state for i in self.instances]):
+            if logger.isEnabledFor(logging.DEBUG):
+                waiting_instances = [i for i in self.instances if i.state['Name'] != state]
+                sample_size = 3
+                sample = [i.id for i in waiting_instances][:sample_size]
+                logger.debug('{size} instances not in state {state}, like: {sample} ...'.format(size=len(waiting_instances), state=state, sample=sample))
+            time.sleep(3)
             # Update metadata for all instances in one shot. We don't want
             # to make a call to AWS for each of potentially hundreds of
             # instances.
@@ -132,7 +142,6 @@ class EC2Cluster(FlintrockCluster):
                         {'Name': 'instance-id', 'Values': [i.id for i in self.instances]}
                     ]))
             (self.master_instance, self.slave_instances) = _get_cluster_master_slaves(instances)
-            time.sleep(3)
 
     def destroy(self):
         self.destroy_check()
@@ -690,7 +699,7 @@ def _create_instances(
     try:
         if spot_price:
             user_data = base64.b64encode(user_data.encode('utf-8')).decode()
-            print("Requesting {c} spot instances at a max price of ${p}...".format(
+            logger.info("Requesting {c} spot instances at a max price of ${p}...".format(
                 c=num_instances, p=spot_price))
             client = ec2.meta.client
             spot_requests = client.request_spot_instances(
@@ -715,7 +724,7 @@ def _create_instances(
             pending_request_ids = request_ids
 
             while pending_request_ids:
-                print("{grant} of {req} instances granted. Waiting...".format(
+                logger.info("{grant} of {req} instances granted. Waiting...".format(
                     grant=num_instances - len(pending_request_ids),
                     req=num_instances))
                 time.sleep(30)
@@ -735,7 +744,7 @@ def _create_instances(
                     r['SpotInstanceRequestId'] for r in spot_requests
                     if r['State'] == 'open']
 
-            print("All {c} instances granted.".format(c=num_instances))
+            logger.info("All {c} instances granted.".format(c=num_instances))
 
             cluster_instances = list(
                 ec2.instances.filter(
@@ -744,7 +753,7 @@ def _create_instances(
                     ]))
         else:
             # Move this to flintrock.py?
-            print("Launching {c} instance{s}...".format(
+            logger.info("Launching {c} instance{s}...".format(
                 c=num_instances,
                 s='' if num_instances == 1 else 's'))
 
@@ -776,7 +785,7 @@ def _create_instances(
         if spot_requests:
             request_ids = [r['SpotInstanceRequestId'] for r in spot_requests]
             if any([r['State'] != 'active' for r in spot_requests]):
-                print("Canceling spot instance requests...", file=sys.stderr)
+                logger.info("Canceling spot instance requests...", file=sys.stderr)
                 client.cancel_spot_instance_requests(
                     SpotInstanceRequestIds=request_ids)
             # Make sure we have the latest information on any launched spot instances.

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -4,7 +4,6 @@ import sys
 import time
 import urllib.request
 import base64
-import os
 import logging
 from collections import namedtuple
 from datetime import datetime
@@ -127,9 +126,8 @@ class EC2Cluster(FlintrockCluster):
         while any([i.state['Name'] != state for i in self.instances]):
             if logger.isEnabledFor(logging.DEBUG):
                 waiting_instances = [i for i in self.instances if i.state['Name'] != state]
-                sample_size = 3
-                sample = [i.id for i in waiting_instances][:sample_size]
-                logger.debug('{size} instances not in state {state}, like: {sample} ...'.format(size=len(waiting_instances), state=state, sample=sample))
+                sample = ', '.join(["'{}'".format(i.id) for i in waiting_instances][:3])
+                logger.debug("{size} instances not in state '{state}': {sample}, ...".format(size=len(waiting_instances), state=state, sample=sample))
             time.sleep(3)
             # Update metadata for all instances in one shot. We don't want
             # to make a call to AWS for each of potentially hundreds of

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -785,7 +785,7 @@ def _create_instances(
         if spot_requests:
             request_ids = [r['SpotInstanceRequestId'] for r in spot_requests]
             if any([r['State'] != 'active' for r in spot_requests]):
-                logger.info("Canceling spot instance requests...", file=sys.stderr)
+                print("Canceling spot instance requests...", file=sys.stderr)
                 client.cancel_spot_instance_requests(
                     SpotInstanceRequestIds=request_ids)
             # Make sure we have the latest information on any launched spot instances.

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -9,6 +9,7 @@ import textwrap
 import urllib.parse
 import urllib.request
 import warnings
+import logging
 
 # External modules
 import click
@@ -36,6 +37,9 @@ if FROZEN:
     THIS_DIR = sys._MEIPASS
 else:
     THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+logger = logging.getLogger('flintrock')
 
 
 def format_message(*, message: str, indent: int=4, wrap: int=70):
@@ -156,6 +160,18 @@ def get_config_file() -> str:
     return config_file
 
 
+def configure_log(debug: bool):
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+    if debug:
+        logger.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+    else:
+        logger.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter('%(message)s'))
+    logger.addHandler(handler)
+
+
 @click.group()
 @click.option(
     '--config',
@@ -163,13 +179,16 @@ def get_config_file() -> str:
     default=get_config_file())
 @click.option('--provider', default='ec2', type=click.Choice(['ec2']))
 @click.version_option(version=__version__)
+# TODO: implement some solution like in https://github.com/pallets/click/issues/108
+@click.option('--debug/--no-debug', default=False, help="Whether to show debug messages")
 @click.pass_context
-def cli(cli_context, config, provider):
+def cli(cli_context, config, provider, debug):
     """
     Flintrock
 
     A command-line tool for launching Apache Spark clusters.
     """
+    configure_log(debug=debug)
     cli_context.obj['provider'] = provider
 
     if os.path.isfile(config):
@@ -316,12 +335,12 @@ def launch(
         if spark_version:
             spark = Spark(version=spark_version, download_source=spark_download_source)
         elif spark_git_commit:
-            print(
+            logger.warning(
                 "Warning: Building Spark takes a long time. "
                 "e.g. 15-20 minutes on an m3.xlarge instance on EC2.")
             if spark_git_commit == 'latest':
                 spark_git_commit = get_latest_commit(spark_git_repository)
-                print("Building Spark at latest commit: {c}".format(c=spark_git_commit))
+                logger.info("Building Spark at latest commit: {c}".format(c=spark_git_commit))
             spark = Spark(
                 git_commit=spark_git_commit,
                 git_repository=spark_git_repository)
@@ -410,7 +429,7 @@ def destroy(cli_context, cluster_name, assume_yes, ec2_region, ec2_vpc_id):
             text="Are you sure you want to destroy this cluster?",
             abort=True)
 
-    print("Destroying {c}...".format(c=cluster.name))
+    logger.info("Destroying {c}...".format(c=cluster.name))
     cluster.destroy()
 
 
@@ -460,21 +479,21 @@ def describe(
     if cluster_name:
         cluster = clusters[0]
         if master_hostname_only:
-            print(cluster.master_host)
+            logger.info(cluster.master_host)
         else:
             cluster.print()
     else:
         if master_hostname_only:
             for cluster in sorted(clusters, key=lambda x: x.name):
-                print(cluster.name + ':', cluster.master_host)
+                logger.info(cluster.name + ':', cluster.master_host)
         else:
-            print("Found {n} cluster{s}{space}{search_area}.".format(
+            logger.info("Found {n} cluster{s}{space}{search_area}.".format(
                 n=len(clusters),
                 s='' if len(clusters) == 1 else 's',
                 space=' ' if search_area else '',
                 search_area=search_area))
             if clusters:
-                print('---')
+                logger.info('---')
                 for cluster in sorted(clusters, key=lambda x: x.name):
                     cluster.print()
 
@@ -558,7 +577,7 @@ def start(cli_context, cluster_name, ec2_region, ec2_vpc_id, ec2_identity_file, 
         raise UnsupportedProviderError(provider)
 
     cluster.start_check()
-    print("Starting {c}...".format(c=cluster_name))
+    logger.info("Starting {c}...".format(c=cluster_name))
     cluster.start(user=user, identity_file=identity_file)
 
 
@@ -596,9 +615,9 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
             text="Are you sure you want to stop this cluster?",
             abort=True)
 
-    print("Stopping {c}...".format(c=cluster_name))
+    logger.info("Stopping {c}...".format(c=cluster_name))
     cluster.stop()
-    print("{c} is now stopped.".format(c=cluster_name))
+    logger.info("{c} is now stopped.".format(c=cluster_name))
 
 
 @cli.command(name='add-slaves')
@@ -719,7 +738,7 @@ def remove_slaves(
         raise UnsupportedProviderError(provider)
 
     if num_slaves > cluster.num_slaves:
-        print(
+        logger.warning(
             "Warning: Cluster has {c} slave{cs}. "
             "You asked to remove {n} slave{ns}."
             .format(
@@ -738,10 +757,10 @@ def remove_slaves(
                       s='' if num_slaves == 1 else 's')),
             abort=True)
 
-    print("Removing {n} slave{s}..."
-          .format(
-              n=num_slaves,
-              s='' if num_slaves == 1 else 's'))
+    logger.info("Removing {n} slave{s}..."
+                .format(
+                    n=num_slaves,
+                    s='' if num_slaves == 1 else 's'))
     cluster.remove_slaves(
         user=user,
         identity_file=identity_file,
@@ -802,7 +821,7 @@ def run_command(
 
     cluster.run_command_check()
 
-    print("Running command on {target}...".format(
+    logger.info("Running command on {target}...".format(
         target="master only" if master_only else "cluster"))
 
     cluster.run_command(
@@ -882,8 +901,8 @@ def copy_file(
         total_size_bytes = file_size_bytes * num_nodes
 
         if total_size_bytes > 10 ** 6:
-            print("WARNING:")
-            print(
+            logger.warning("WARNING:")
+            logger.warning(
                 format_message(
                     message="""\
                         You are trying to upload {total_size} bytes ({size} bytes x {count}
@@ -903,7 +922,7 @@ def copy_file(
                 default=True,
                 abort=True)
 
-    print("Copying file to {target}...".format(
+    logger.info("Copying file to {target}...".format(
         target="master only" if master_only else "cluster"))
 
     cluster.copy_file(
@@ -974,7 +993,7 @@ def configure(cli_context, locate):
     config_file = get_config_file()
 
     if not os.path.isfile(config_file):
-        print("Initializing config file from template...")
+        logger.info("Initializing config file from template...")
         os.makedirs(os.path.dirname(config_file), exist_ok=True)
         shutil.copyfile(
             src=os.path.join(THIS_DIR, 'config.yaml.template'),

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -162,7 +162,6 @@ def get_config_file() -> str:
 
 def configure_log(debug: bool):
     root_logger = logging.getLogger('flintrock')
-    import sys
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG)
     if debug:
@@ -190,18 +189,19 @@ def cli(cli_context, config, provider, debug):
 
     A command-line tool for launching Apache Spark clusters.
     """
-    configure_log(debug=debug)
     cli_context.obj['provider'] = provider
 
     if os.path.isfile(config):
         with open(config) as f:
             config_raw = yaml.safe_load(f)
+            debug = config_raw.get('debug') or debug
             config_map = config_to_click(normalize_keys(config_raw))
 
         cli_context.default_map = config_map
     else:
         if config != get_config_file():
             raise FileNotFoundError(errno.ENOENT, 'No such file', config)
+    configure_log(debug=debug)
 
 
 @cli.command()

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -39,7 +39,7 @@ else:
     THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-logger = logging.getLogger('flintrock')
+logger = logging.getLogger('flintrock.flintrock')
 
 
 def format_message(*, message: str, indent: int=4, wrap: int=70):
@@ -161,15 +161,17 @@ def get_config_file() -> str:
 
 
 def configure_log(debug: bool):
-    handler = logging.StreamHandler()
+    root_logger = logging.getLogger('flintrock')
+    import sys
+    handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG)
     if debug:
-        logger.setLevel(logging.DEBUG)
-        handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+        root_logger.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter('%(asctime)s - flintrock.%(module)-9s - %(levelname)-5s - %(message)s'))
     else:
-        logger.setLevel(logging.INFO)
+        root_logger.setLevel(logging.INFO)
         handler.setFormatter(logging.Formatter('%(message)s'))
-    logger.addHandler(handler)
+    root_logger.addHandler(handler)
 
 
 @click.group()
@@ -180,7 +182,7 @@ def configure_log(debug: bool):
 @click.option('--provider', default='ec2', type=click.Choice(['ec2']))
 @click.version_option(version=__version__)
 # TODO: implement some solution like in https://github.com/pallets/click/issues/108
-@click.option('--debug/--no-debug', default=False, help="Whether to show debug messages")
+@click.option('--debug/--no-debug', default=False, help="Show debug information.")
 @click.pass_context
 def cli(cli_context, config, provider, debug):
     """

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -4,6 +4,7 @@ import shlex
 import sys
 import textwrap
 import urllib.request
+import logging
 
 # External modules
 import paramiko
@@ -20,6 +21,9 @@ else:
     THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
 SCRIPTS_DIR = os.path.join(THIS_DIR, 'scripts')
+
+
+logger = logging.getLogger('flintrock.services')
 
 
 # TODO: Cache these files. (?) They are being read potentially tens or
@@ -117,7 +121,7 @@ class HDFS(FlintrockService):
             self,
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
-        print("[{h}] Installing HDFS...".format(
+        logger.info("[{h}] Installing HDFS...".format(
             h=ssh_client.get_transport().getpeername()[0]))
 
         with ssh_client.open_sftp() as sftp:
@@ -175,7 +179,7 @@ class HDFS(FlintrockService):
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
         host = ssh_client.get_transport().getpeername()[0]
-        print("[{h}] Configuring HDFS master...".format(h=host))
+        logger.info("[{h}] Configuring HDFS master...".format(h=host))
 
         ssh_check_output(
             client=ssh_client,
@@ -199,7 +203,7 @@ class HDFS(FlintrockService):
             print("HDFS health check failed.", file=sys.stderr)
             raise
 
-        print("HDFS online.")
+        logger.info("HDFS online.")
 
 
 class Spark(FlintrockService):
@@ -227,7 +231,7 @@ class Spark(FlintrockService):
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
 
-        print("[{h}] Installing Spark...".format(
+        logger.info("[{h}] Installing Spark...".format(
             h=ssh_client.get_transport().getpeername()[0]))
 
         try:
@@ -311,7 +315,7 @@ class Spark(FlintrockService):
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
         host = ssh_client.get_transport().getpeername()[0]
-        print("[{h}] Configuring Spark master...".format(h=host))
+        logger.info("[{h}] Configuring Spark master...".format(h=host))
 
         # TODO: Maybe move this shell script out to some separate file/folder
         #       for the Spark service.
@@ -346,7 +350,7 @@ class Spark(FlintrockService):
             raise
 
         # TODO: Don't print here. Return this and let the caller print.
-        print(textwrap.dedent(
+        logger.info(textwrap.dedent(
             """\
             Spark Health Report:
               * Master: {status}

--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -84,17 +84,17 @@ def get_ssh_client(
                 logger.info("[{h}] SSH online.".format(h=host))
             break
         except socket.timeout as e:
-            logger.debug("[{h}] SSH got a timeout...".format(h=host))
+            logger.debug("[{h}] SSH timeout.".format(h=host))
             time.sleep(5)
         except paramiko.ssh_exception.NoValidConnectionsError as e:
             if any(error.errno != errno.ECONNREFUSED for error in e.errors.values()):
                 raise
-            logger.debug("[{h}] SSH got an exception: {e}".format(h=host, e=e))
+            logger.debug("[{h}] SSH exception: {e}".format(h=host, e=e))
             time.sleep(5)
         # We get this exception during startup with CentOS but not Amazon Linux,
         # for some reason.
         except paramiko.ssh_exception.AuthenticationException as e:
-            logger.debug("[{h}] SSH got an AuthenticationException".format(h=host))
+            logger.debug("[{h}] SSH AuthenticationException.".format(h=host))
             time.sleep(5)
     else:
         raise SSHError(


### PR DESCRIPTION
This PR makes the following changes:
- Add a --debug flag to enable a timestamped view of output
- Add debug messages for instance launching and ssh connection

I tested this PR by launching a cluster. Output sample:
```
2017-01-23 20:34:50,008 Requesting 101 spot instances at a max price of $0.04...
2017-01-23 20:34:50,675 0 of 101 instances granted. Waiting...
2017-01-23 20:35:21,182 All 101 instances granted.
2017-01-23 20:35:39,665 72 instances not in state running, like: ['i-0ff168f921510cf35', 'i-05cabf994eb94dba8', 'i-039411476cc0bd181'] ...
2017-01-23 20:35:44,000 5 instances not in state running, like: ['i-02fc1fb06deb09384', 'i-01333c5213535b208', 'i-072986101dade82f9'] ...
2017-01-23 20:35:48,085 5 instances not in state running, like: ['i-02fc1fb06deb09384', 'i-01333c5213535b208', 'i-072986101dade82f9'] ...
2017-01-23 20:35:52,124 2 instances not in state running, like: ['i-072986101dade82f9', 'i-0dbc7b19682a2b0d6'] ...
2017-01-23 20:37:02,079 [54.237.237.187] SSH got an exception: [Errno None] Unable to connect to port 22 on 54.237.237.187
2017-01-23 20:37:02,781 [107.23.122.133] SSH online.
```

Fixes #177.
Helps #47 (I'm not sure it completely solves it).
