### PR TITLE
Avoid exception if instance has no tags

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -936,6 +936,7 @@ def launch(
         if isinstance(e, InterruptedEC2Operation):
             cleanup_instances = e.instances
         else:
+            # FIXME: there is no guarantee that cluster_instances is defined
             cleanup_instances = cluster_instances
         _cleanup_instances(
             instances=cleanup_instances,
@@ -1024,7 +1025,8 @@ def _get_cluster_master_slaves(
     slave_instances = []
 
     for instance in instances:
-        for tag in instance.tags:
+        # FIXME: we should try a better strategy to handle inconsistent clusters
+        for tag in (instance.tags or []):
             if tag['Key'] == 'flintrock-role':
                 if tag['Value'] == 'master':
                     if master_instance is not None:


### PR DESCRIPTION
While testing some code, I canceled the spot request. An exception was raised but the try-except itself raised an error (UnboundLocalError: local variable 'cluster_instances' referenced before assignment):
```
2017-01-24 19:20:24,421 0 of 101 instances granted. Waiting...
^CTraceback (most recent call last):
  File "/home/allan/flintrock/flintrock/ec2.py", line 730, in _create_instances
    time.sleep(30)
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/allan/flintrock/flintrock/ec2.py", line 905, in launch
    user_data=user_data)
  File "/home/allan/flintrock/flintrock/ec2.py", line 788, in _create_instances
    logger.info("Canceling spot instance requests...", file=sys.stderr)
  File "/usr/lib/python3.4/logging/__init__.py", line 1274, in info
    self._log(INFO, msg, args, **kwargs)
TypeError: _log() got an unexpected keyword argument 'file'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/allan/flintrock/standalone.py", line 11, in <module>
    sys.exit(main())   
  File "/home/allan/flintrock/flintrock/flintrock.py", line 1087, in main
    cli(obj={})
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/allan/flintrock/flintrock/flintrock.py", line 371, in launch
    user_data=ec2_user_data)
  File "/home/allan/flintrock/flintrock/ec2.py", line 54, in wrapper
    res = func(*args, **kwargs)
  File "/home/allan/flintrock/flintrock/ec2.py", line 948, in launch
    cleanup_instances = cluster_instances
UnboundLocalError: local variable 'cluster_instances' referenced before assignment
```

Then I tried killing the cluster but caught:
```
Traceback (most recent call last):                                                                                                                                           
  File "/home/allan/flintrock/standalone.py", line 11, in <module>                                                                                                           
    sys.exit(main())   
  File "/home/allan/flintrock/flintrock/flintrock.py", line 1087, in main
    cli(obj={})
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/allan/flintrock/flintrock/flintrock.py", line 422, in destroy
    vpc_id=ec2_vpc_id) 
  File "/home/allan/flintrock/flintrock/ec2.py", line 964, in get_cluster
    vpc_id=vpc_id)
  File "/home/allan/flintrock/flintrock/ec2.py", line 1009, in get_clusters
    for cluster_name in found_cluster_names]
  File "/home/allan/flintrock/flintrock/ec2.py", line 1009, in <listcomp>
    for cluster_name in found_cluster_names]
  File "/home/allan/flintrock/flintrock/ec2.py", line 1060, in _compose_cluster
    (master_instance, slave_instances) = _get_cluster_master_slaves(instances)
  File "/home/allan/flintrock/flintrock/ec2.py", line 1036, in _get_cluster_master_slaves
    for tag in instance.tags:
TypeError: 'NoneType' object is not iterable
```

Note: if you prefer to create one (or two) issues for the problems reported, feel free. I used FIXMEs because this is what I would do normally in a situation like this