### PR TITLE
Added --spark-executor-instances to specify how many instances by worker

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -8,6 +8,7 @@ services:
     #   - Spark must be pre-built
     #   - must be a tar.gz file
     # download-source: "https://www.example.com/files/spark/{v}/spark-{v}.tar.gz"
+    # executor-instances: 1
   hdfs:
     version: 2.7.3
     # optional; defaults to download from a dynamically selected Apache mirror

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -430,6 +430,7 @@ def generate_template_mapping(
     # If we add additional services later on we may want to refactor
     # this to take a list of services and dynamically pull the service
     # name.
+    spark_executor_instances: int,
     hadoop_version: str,
     spark_version: str
 ) -> dict:
@@ -458,6 +459,8 @@ def generate_template_mapping(
         'hadoop_short_version': '.'.join(hadoop_version.split('.')[:2]),
         'spark_version': spark_version,
         'spark_short_version': '.'.join(spark_version.split('.')[:2]),
+
+        'spark_executor_instances': spark_executor_instances,
 
         'hadoop_root_dir': hadoop_root_dir,
         'hadoop_ephemeral_dirs': hadoop_ephemeral_dirs,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -193,6 +193,8 @@ def cli(cli_context, config, provider):
               default='http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json',
               show_default=True)
 @click.option('--install-spark/--no-install-spark', default=True)
+@click.option('--spark-executor-instances', default=1,
+              help="How many executor instances per worker.")
 @click.option('--spark-version',
               default='2.1.0',
               help="Spark release version to install.")
@@ -245,6 +247,7 @@ def launch(
         hdfs_version,
         hdfs_download_source,
         install_spark,
+        spark_executor_instances,
         spark_version,
         spark_git_commit,
         spark_git_repository,
@@ -316,6 +319,7 @@ def launch(
     if install_spark:
         if spark_version:
             spark = Spark(
+                spark_executor_instances=spark_executor_instances,
                 version=spark_version,
                 hadoop_version=hdfs_version,
                 download_source=spark_download_source,
@@ -328,6 +332,7 @@ def launch(
                 spark_git_commit = get_latest_commit(spark_git_repository)
                 print("Building Spark at latest commit: {c}".format(c=spark_git_commit))
             spark = Spark(
+                spark_executor_instances=spark_executor_instances,
                 git_commit=spark_git_commit,
                 git_repository=spark_git_repository,
                 hadoop_version=hdfs_version,

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -309,13 +309,6 @@ class Spark(FlintrockService):
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
 
-        mapping = generate_template_mapping(
-            cluster=cluster,
-            spark_executor_instances=self.spark_executor_instances,
-            hadoop_version=self.hadoop_version,
-            spark_version=self.version,
-        )
-
         template_paths = [
             'spark/conf/spark-env.sh',
             'spark/conf/slaves',
@@ -332,6 +325,7 @@ class Spark(FlintrockService):
                             path=os.path.join(THIS_DIR, "templates", template_path),
                             mapping=generate_template_mapping(
                                 cluster=cluster,
+                                spark_executor_instances=self.spark_executor_instances,
                                 hadoop_version=self.hadoop_version,
                                 spark_version=self.version or self.git_commit,
                             ))),

--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -3,7 +3,8 @@
 export SPARK_LOCAL_DIRS="{spark_root_ephemeral_dirs}"
 
 # Standalone cluster options
-export SPARK_EXECUTOR_INSTANCES="1"
+export SPARK_EXECUTOR_INSTANCES="{spark_executor_instances}"
+export SPARK_EXECUTOR_CORES="$(($(nproc) / {spark_executor_instances}))"
 export SPARK_WORKER_CORES="$(nproc)"
 
 export SPARK_MASTER_HOST="{master_host}"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,7 @@ def test_templates(dummy_cluster):
                     cluster=dummy_cluster,
                     hadoop_version='',
                     spark_version='',
+                    spark_executor_instances=0,
                 )
                 get_formatted_template(
                     path=template_path,


### PR DESCRIPTION
This PR makes the SPARK_EXECUTOR_INSTANCES be configurable.

I tested this PR by manually launching a cluster and running a job.