### PR TITLE
Added /media/tmp for temporary usage that needs more space than /tmp

### DIFF
--- a/flintrock/scripts/setup-ephemeral-storage.py
+++ b/flintrock/scripts/setup-ephemeral-storage.py
@@ -12,7 +12,7 @@ The resulting structure we create is as follows:
         /root: The instance's root volume.
         /ephemeral[0-N]: Instance store volumes.
         /persistent[0-N]: EBS volumes.
-        /tmp: A temporary directory with lots of space (either /ephemeral* or /persistent*)
+        /tmp: A temporary directory with lots of space.
 
 WARNING: Be conscious about what this script prints to stdout, as that
          output is parsed by Flintrock.
@@ -160,15 +160,11 @@ def create_root_dir():
     return path
 
 
-def create_tmp_dir(devices):
+def create_tmp_dir(target):
     """
-    Create a folder that any services can use as temporary directory for big files
+    Create a folder that services can use as a temporary directory for big files.
     """
     path = '/media/tmp'
-    if devices:
-        target = devices[0].mount_point
-    else:
-        target = '/tmp'
     subprocess.check_output([
         'sudo', 'ln', '-s', target, path])
     subprocess.check_output(
@@ -200,7 +196,11 @@ if __name__ == '__main__':
     mount_devices(ephemeral_devices)
 
     root_dir = create_root_dir()
-    create_tmp_dir(ephemeral_devices)
+    if ephemeral_devices:
+        tmp_dir = ephemeral_devices[0].mount_point
+    else:
+        tmp_dir = '/tmp'
+    create_tmp_dir(tmp_dir)
 
     print(json.dumps(
         {


### PR DESCRIPTION
This PR makes creates a /media/tmp linking to /ephemeral*

A usage example is to set SPARK_WORKER_DIR to this.

I tested this PR by launching a cluster.
