### PR TITLE
add option to tag ec2 instances

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -37,8 +37,8 @@ providers:
     #   - group-name2
     # instance-profile-name:
     # tags:
-    #   - key1,value1
-    #   - key2,value2
+    #   - key1,value1 (or 'key1, value1' or 'key1,')
+    #   - key2,value2 (or 'key2, value2' or 'key2,')
     tenancy: default  # default | dedicated
     ebs-optimized: no  # yes | no
     instance-initiated-shutdown-behavior: terminate  # terminate | stop

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -36,6 +36,9 @@ providers:
     #   - group-name1
     #   - group-name2
     # instance-profile-name:
+    # tags:
+    #   - key1,value1
+    #   - key2,value2
     tenancy: default  # default | dedicated
     ebs-optimized: no  # yes | no
     instance-initiated-shutdown-behavior: terminate  # terminate | stop

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -37,8 +37,9 @@ providers:
     #   - group-name2
     # instance-profile-name:
     # tags:
-    #   - key1,value1 (or 'key1, value1' or 'key1,')
-    #   - key2,value2 (or 'key2, value2' or 'key2,')
+    #   - key1,value1
+    #   - key2, value2  # leading/trailing spaces are trimmed
+    #   - key3,  # value will be empty
     tenancy: default  # default | dedicated
     ebs-optimized: no  # yes | no
     instance-initiated-shutdown-behavior: terminate  # terminate | stop

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -1018,15 +1018,17 @@ def validate_tags(ctx, param, value):
     """
     Validate and parse optional EC2 tags.
     """
+    err_msg = ("Tags need to be specified as 'Key,Value' pairs "
+               "separated by a single comma. Key cannot be empty "
+               "or be made up entirely of whitespace.")
     tags = value
     result = []
     for tag in tags:
+        if ',' not in tag:
+            raise click.BadParameter(err_msg)
         key, value = [word.strip() for word in tag.split(',', maxsplit=1)]
         if not key or ',' in value:
-            raise click.BadParameter(
-                "Tags need to be specified as 'Key,Value' pairs "
-                "separated by a single comma. Key cannot be empty "
-                "or be made up entirely of whitespace.")
+            raise click.BadParameter(err_msg)
         result.append({'Key': key, 'Value': value})
 
     return result

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -1014,7 +1014,11 @@ def get_clusters(*, cluster_names: list=[], region: str, vpc_id: str) -> list:
     return clusters
 
 
-def validate_tags(ctx, param, value):
+def cli_validate_tags(ctx, param, value):
+    return validate_tags(value)
+
+
+def validate_tags(value):
     """
     Validate and parse optional EC2 tags.
     """

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -1024,10 +1024,10 @@ def validate_tags(ctx, param, value):
     tags = value
     result = []
     for tag in tags:
-        if ',' not in tag:
+        if tag.count(',') != 1:
             raise click.BadParameter(err_msg)
         key, value = [word.strip() for word in tag.split(',', maxsplit=1)]
-        if not key or ',' in value:
+        if not key:
             raise click.BadParameter(err_msg)
         result.append({'Key': key, 'Value': value})
 

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -1014,6 +1014,24 @@ def get_clusters(*, cluster_names: list=[], region: str, vpc_id: str) -> list:
     return clusters
 
 
+def validate_tags(ctx, param, value):
+    """
+    Validate and parse optional ec2 tags as supplied on command line.
+    """
+    ec2_tags = value
+    for ec2_tag in ec2_tags:
+        if ec2_tag.count(',') != 1 or not ec2_tag.split(',')[0]:
+            raise click.BadParameter(
+                "tags need to be specified as 'Key,Value' pairs "
+                "separated by a single comma. Key cannot be empty.")
+
+    ec2_tags = [{'Key': tag.split(',')[0].strip(),
+                 'Value': tag.split(',')[1].strip()}
+                for tag in ec2_tags]
+
+    return ec2_tags
+
+
 def _get_cluster_name(instance: 'boto3.resources.factory.ec2.Instance') -> str:
     """
     Given an EC2 instance, get the name of the Flintrock cluster it belongs to.

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -1016,20 +1016,20 @@ def get_clusters(*, cluster_names: list=[], region: str, vpc_id: str) -> list:
 
 def validate_tags(ctx, param, value):
     """
-    Validate and parse optional ec2 tags as supplied on command line.
+    Validate and parse optional EC2 tags.
     """
-    ec2_tags = value
-    for ec2_tag in ec2_tags:
-        if ec2_tag.count(',') != 1 or not ec2_tag.split(',')[0]:
+    tags = value
+    result = []
+    for tag in tags:
+        key, value = [word.strip() for word in tag.split(',', maxsplit=1)]
+        if not key or ',' in value:
             raise click.BadParameter(
-                "tags need to be specified as 'Key,Value' pairs "
-                "separated by a single comma. Key cannot be empty.")
+                "Tags need to be specified as 'Key,Value' pairs "
+                "separated by a single comma. Key cannot be empty "
+                "or be made up entirely of whitespace.")
+        result.append({'Key': key, 'Value': value})
 
-    ec2_tags = [{'Key': tag.split(',')[0].strip(),
-                 'Value': tag.split(',')[1].strip()}
-                for tag in ec2_tags]
-
-    return ec2_tags
+    return result
 
 
 def _get_cluster_name(instance: 'boto3.resources.factory.ec2.Instance') -> str:

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -237,9 +237,9 @@ def cli(cli_context, config, provider):
               type=click.File(mode='r', encoding='utf-8'),
               help="Path to EC2 user data script that will run on instance launch.")
 @click.option('--ec2-tag', 'ec2_tags',
+              callback=ec2.validate_tags,
               multiple=True,
-              help="Additional tags (Key,Value pairs) to assign to the instances. "
-                   "You can specify this option multiple times.")
+              help="Additional tags (e.g. 'Key,Value') to assign to the instances.")
 @click.pass_context
 def launch(
         cli_context,
@@ -338,22 +338,6 @@ def launch(
                 hadoop_version=hdfs_version,
             )
         services += [spark]
-
-    # Format ec2 tags
-    if ec2_tags:
-        for ec2_tag in ec2_tags:
-            if ec2_tag.count(',') != 1:
-                raise UsageError(
-                    "Error: EC2 tags need to be specified as Key,Value pairs "
-                    "separated by a single comma")
-            k, v = ec2_tag.split(',')
-            if not len(k) or not len(v):
-                raise UsageError(
-                    "Error: An EC2 tag seems to have a missing key or value")
-
-        ec2_tags = [{'Key': tag.split(',')[0],
-                     'Value': tag.split(',')[1]}
-                    for tag in ec2_tags]
 
     if provider == 'ec2':
         return ec2.launch(
@@ -642,9 +626,9 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 @click.option('--ec2-spot-price', type=float)
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-tag', 'ec2_tags',
+              callback=ec2.validate_tags,
               multiple=True,
-              help="Additional tags (Key,Value pairs) to assign to the instances. "
-                   "You can specify this option multiple times.")
+              help="Additional tags (e.g. 'Key,Value') to assign to the instances.")
 @click.pass_context
 def add_slaves(
         cli_context,
@@ -673,22 +657,6 @@ def add_slaves(
             '--ec2-identity-file',
             '--ec2-user'],
         scope=locals())
-
-    # Format ec2 tags
-    if ec2_tags:
-        for ec2_tag in ec2_tags:
-            if ec2_tag.count(',') != 1:
-                raise UsageError(
-                    "Error: EC2 tags need to be specified as Key,Value pairs "
-                    "separated by a single comma")
-            k, v = ec2_tag.split(',')
-            if not len(k) or not len(v):
-                raise UsageError(
-                    "Error: An EC2 tag seems to have a missing key or value")
-
-        ec2_tags = [{'Key': tag.split(',')[0],
-                     'Value': tag.split(',')[1]}
-                    for tag in ec2_tags]
 
     if provider == 'ec2':
         cluster = ec2.get_cluster(

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -237,7 +237,7 @@ def cli(cli_context, config, provider):
               type=click.File(mode='r', encoding='utf-8'),
               help="Path to EC2 user data script that will run on instance launch.")
 @click.option('--ec2-tag', 'ec2_tags',
-              callback=ec2.validate_tags,
+              callback=ec2.cli_validate_tags,
               multiple=True,
               help="Additional tags (e.g. 'Key,Value') to assign to the instances. "
                    "You can specify this option multiple times.")
@@ -627,7 +627,7 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 @click.option('--ec2-spot-price', type=float)
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-tag', 'ec2_tags',
-              callback=ec2.validate_tags,
+              callback=ec2.cli_validate_tags,
               multiple=True,
               help="Additional tags (e.g. 'Key,Value') to assign to the instances. "
                    "You can specify this option multiple times.")

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -239,7 +239,8 @@ def cli(cli_context, config, provider):
 @click.option('--ec2-tag', 'ec2_tags',
               callback=ec2.validate_tags,
               multiple=True,
-              help="Additional tags (e.g. 'Key,Value') to assign to the instances.")
+              help="Additional tags (e.g. 'Key,Value') to assign to the instances. "
+                   "You can specify this option multiple times.")
 @click.pass_context
 def launch(
         cli_context,
@@ -628,7 +629,8 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 @click.option('--ec2-tag', 'ec2_tags',
               callback=ec2.validate_tags,
               multiple=True,
-              help="Additional tags (e.g. 'Key,Value') to assign to the instances.")
+              help="Additional tags (e.g. 'Key,Value') to assign to the instances. "
+                   "You can specify this option multiple times.")
 @click.pass_context
 def add_slaves(
         cli_context,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -240,7 +240,6 @@ def cli(cli_context, config, provider):
               multiple=True,
               help="Additional tags (Key,Value pairs) to assign to the instances. "
                    "You can specify this option multiple times.")
-
 @click.pass_context
 def launch(
         cli_context,
@@ -716,7 +715,6 @@ def add_slaves(
         user=user,
         identity_file=identity_file)
     cluster.add_slaves_check()
-
 
     if provider == 'ec2':
         cluster.add_slaves(

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,0 +1,71 @@
+import pytest
+import click
+from click.testing import CliRunner
+
+from flintrock.ec2 import validate_tags
+
+
+def test_validate_tags():
+    @click.command()
+    @click.option('--ec2-tag', 'ec2_tags',
+                  callback=validate_tags,
+                  multiple=True,
+                  help="Additional tags (e.g. 'Key,Value') to assign to the instances. "
+                       "You can specify this option multiple times.")
+    def cli(ec2_tags):
+        click.echo(ec2_tags)
+
+    runner = CliRunner()
+
+    # cases where validation and parsing should return formatted tags
+    positive_test_cases = [("k1,v1", "'Key': 'k1'", "'Value': 'v1'"),
+                           ("k2, v2 ", "'Key': 'k2'", "'Value': 'v2'"),
+                           ("k3,", "'Key': 'k3'", "'Value': ''")]
+    for test_case in positive_test_cases:
+        result = runner.invoke(cli, ["--ec2-tag", test_case[0]])
+        assert test_case[1] in result.output and test_case[2] in result.output
+        assert result.exit_code == 0
+
+    # one case where multiple tags are supplied
+    result = runner.invoke(cli, ["--ec2-tag", 'k1,v1', "--ec2-tag", 'k2,v2'])
+    assert "'Key': 'k1'" in result.output and "'Key': 'k2'" in result.output
+    assert result.exit_code == 0
+
+    # cases where validation should return error
+    negative_test_cases = ["k1", "k2,v2,", "k3,,v3", ",v4"]
+    for test_case in negative_test_cases:
+        result = runner.invoke(cli, ["--ec2-tag", test_case])
+        assert result.output.startswith("Usage:")
+        assert result.exit_code == 2
+
+
+def test_validate_args2():
+    # List of test cases; each test case is a tuple, with first element
+    # the input and the second element the expected output
+    positive_test_cases = [
+        # basic case
+        (['k1,v1'], [{'Key': 'k1', 'Value': 'v1'}]),
+
+        # strips whitespace?
+        (['k2, v2 '], [{'Key': 'k2', 'Value': 'v2'}]),
+
+        # empty Value
+        (['k3,'], [{'Key': 'k3', 'Value': ''}]),
+
+        # multiple tags
+        (['k4,v4', 'k5,v5'],
+         [{'Key': 'k4', 'Value': 'v4'}, {'Key': 'k5', 'Value': 'v5'}])]
+
+    for test_case in positive_test_cases:
+        ec2_tags = validate_tags(None, None, test_case[0])
+        assert(isinstance(ec2_tags, list))
+        for i, ec2_tag in enumerate(ec2_tags):
+            expected_dict = test_case[1][i]
+            for k in expected_dict:
+                assert k in ec2_tag
+                assert ec2_tag[k] == expected_dict[k]
+
+    negative_test_cases = [["k1"], ["k2,v2,"], ["k3,,v3"], [",v4"]]
+    for test_case in negative_test_cases:
+        with pytest.raises(click.BadParameter):
+            validate_tags(None, None, test_case)

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -18,7 +18,7 @@ def test_validate_tags():
          [{'Key': 'k4', 'Value': 'v4'}, {'Key': 'k5', 'Value': 'v5'}])]
 
     for test_case in positive_test_cases:
-        ec2_tags = cli_validate_tags(test_case[0])
+        ec2_tags = validate_tags(test_case[0])
         assert(isinstance(ec2_tags, list))
         for i, ec2_tag in enumerate(ec2_tags):
             expected_dict = test_case[1][i]
@@ -29,8 +29,4 @@ def test_validate_tags():
     negative_test_cases = [["k1"], ["k2,v2,"], ["k3,,v3"], [",v4"]]
     for test_case in negative_test_cases:
         with pytest.raises(click.BadParameter):
-            cli_validate_tags(test_case)
-
-
-def cli_validate_tags(args):
-    return validate_tags(None, None, args)
+            validate_tags(test_case)

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,63 +1,24 @@
 import pytest
 import click
-from click.testing import CliRunner
-
 from flintrock.ec2 import validate_tags
 
 
 def test_validate_tags():
-    @click.command()
-    @click.option('--ec2-tag', 'ec2_tags',
-                  callback=validate_tags,
-                  multiple=True,
-                  help="Additional tags (e.g. 'Key,Value') to assign to the instances. "
-                       "You can specify this option multiple times.")
-    def cli(ec2_tags):
-        click.echo(ec2_tags)
-
-    runner = CliRunner()
-
-    # cases where validation and parsing should return formatted tags
-    positive_test_cases = [("k1,v1", "'Key': 'k1'", "'Value': 'v1'"),
-                           ("k2, v2 ", "'Key': 'k2'", "'Value': 'v2'"),
-                           ("k3,", "'Key': 'k3'", "'Value': ''")]
-    for test_case in positive_test_cases:
-        result = runner.invoke(cli, ["--ec2-tag", test_case[0]])
-        assert test_case[1] in result.output and test_case[2] in result.output
-        assert result.exit_code == 0
-
-    # one case where multiple tags are supplied
-    result = runner.invoke(cli, ["--ec2-tag", 'k1,v1', "--ec2-tag", 'k2,v2'])
-    assert "'Key': 'k1'" in result.output and "'Key': 'k2'" in result.output
-    assert result.exit_code == 0
-
-    # cases where validation should return error
-    negative_test_cases = ["k1", "k2,v2,", "k3,,v3", ",v4"]
-    for test_case in negative_test_cases:
-        result = runner.invoke(cli, ["--ec2-tag", test_case])
-        assert result.output.startswith("Usage:")
-        assert result.exit_code == 2
-
-
-def test_validate_args2():
     # List of test cases; each test case is a tuple, with first element
     # the input and the second element the expected output
     positive_test_cases = [
         # basic case
         (['k1,v1'], [{'Key': 'k1', 'Value': 'v1'}]),
-
         # strips whitespace?
         (['k2, v2 '], [{'Key': 'k2', 'Value': 'v2'}]),
-
         # empty Value
         (['k3,'], [{'Key': 'k3', 'Value': ''}]),
-
         # multiple tags
         (['k4,v4', 'k5,v5'],
          [{'Key': 'k4', 'Value': 'v4'}, {'Key': 'k5', 'Value': 'v5'}])]
 
     for test_case in positive_test_cases:
-        ec2_tags = validate_tags(None, None, test_case[0])
+        ec2_tags = cli_validate_tags(test_case[0])
         assert(isinstance(ec2_tags, list))
         for i, ec2_tag in enumerate(ec2_tags):
             expected_dict = test_case[1][i]
@@ -68,4 +29,8 @@ def test_validate_args2():
     negative_test_cases = [["k1"], ["k2,v2,"], ["k3,,v3"], [",v4"]]
     for test_case in negative_test_cases:
         with pytest.raises(click.BadParameter):
-            validate_tags(None, None, test_case)
+            cli_validate_tags(test_case)
+
+
+def cli_validate_tags(args):
+    return validate_tags(None, None, args)


### PR DESCRIPTION
This PR allows users to label their EC2 instances with custom tags. An EC2 tag is added with the --ec2-tag option, where each tag is a Key,Value pair separated by a comma. The ec2-tag can be specified multiple times.

I tested this both for launching new clusters and appending slaves to existing clusters. As far as I can tell, it works as expected.

Speaking of the code itself, there's a common formatting step that takes the tags as supplied on the command line and transforms them into a dictionary that EC2 expects. This piece of code is replicated for launching and adding slaves as I didn't know the proper place to put it if we wanted to wrap it as a function (the ec2.py file?). This would be trivial to do if desired.

Cheers,
Luke

Fixes #182 


