### PR TITLE
Support users with non-standard home directories

### DIFF
--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -140,8 +140,8 @@ class FlintrockCluster:
             manifest_raw = ssh_check_output(
                 client=master_ssh_client,
                 command="""
-                    cat ~{u}/.flintrock-manifest.json
-                """.format(u=shlex.quote(user)))
+                    cat "$HOME/.flintrock-manifest.json"
+                """)
             # TODO: Would it be better if storage (ephemeral and otherwise) was
             #       implemented as a Flintrock service and tracked in the manifest?
             ephemeral_dirs_raw = ssh_check_output(
@@ -570,10 +570,10 @@ def setup_node(
         command="""
             set -e
 
-            echo {private_key} > ~/.ssh/id_rsa
-            echo {public_key} >> ~/.ssh/authorized_keys
+            echo {private_key} > "$HOME/.ssh/id_rsa"
+            echo {public_key} >> "$HOME/.ssh/authorized_keys"
 
-            chmod 400 ~/.ssh/id_rsa
+            chmod 400 "$HOME/.ssh/id_rsa"
         """.format(
             private_key=shlex.quote(cluster.ssh_key_pair.private),
             public_key=shlex.quote(cluster.ssh_key_pair.public)))
@@ -644,11 +644,11 @@ def provision_cluster(
         ssh_check_output(
             client=master_ssh_client,
             command="""
-                echo {m} > ~{u}/.flintrock-manifest.json
-                chmod go-rw ~{u}/.flintrock-manifest.json
+                echo {m} > "$HOME/.flintrock-manifest.json"
+                chmod go-rw "$HOME/.flintrock-manifest.json"
             """.format(
-                m=shlex.quote(json.dumps(manifest, indent=4, sort_keys=True)),
-                u=shlex.quote(user)))
+                m=shlex.quote(json.dumps(manifest, indent=4, sort_keys=True))
+            ))
 
         for service in services:
             service.configure_master(

--- a/flintrock/templates/hadoop/conf/hadoop-env.sh
+++ b/flintrock/templates/hadoop/conf/hadoop-env.sh
@@ -1,2 +1,2 @@
-export HADOOP_HOME="/home/$(logname)/hadoop"
+export HADOOP_HOME="$HOME/hadoop"
 export HADOOP_SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=5"

--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -9,7 +9,7 @@ export SPARK_WORKER_CORES="$(nproc)"
 export SPARK_MASTER_HOST="{master_host}"
 
 # TODO: Make this dependent on HDFS install.
-export HADOOP_CONF_DIR="/home/$(logname)/hadoop/conf"
+export HADOOP_CONF_DIR="$HOME/hadoop/conf"
 
 # TODO: Make this non-EC2-specific.
 # Bind Spark's web UIs to this machine's public EC2 hostname


### PR DESCRIPTION
This PR builds on #176 by @douglaz and replaces all instances of `~/` and `/home/` with `$HOME`.

I tested this PR by launching a couple of clusters with both Spark and HDFS enabled, and testing various operations.

@douglaz - I'm going to merge this in, but let me know if you have any issues when using Flintrock with those `root`-based AMIs you mentioned to me.

Closes #176.
