### PR TITLE
Let the min root ebs size be configurable

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -40,6 +40,7 @@ providers:
     #   - key1,value1
     #   - key2, value2  # leading/trailing spaces are trimmed
     #   - key3,  # value will be empty
+    # min-root-ebs-size-gb: <size-gb>
     tenancy: default  # default | dedicated
     ebs-optimized: no  # yes | no
     instance-initiated-shutdown-behavior: terminate  # terminate | stop

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -233,12 +233,14 @@ class EC2Cluster(FlintrockCluster):
             identity_file: str,
             num_slaves: int,
             spot_price: float,
+            min_root_ebs_size_gb: int,
             tags: list,
             assume_yes: bool):
         security_group_ids = [
             group['GroupId']
             for group in self.master_instance.security_groups]
         block_device_mappings = get_ec2_block_device_mappings(
+            min_root_ebs_size_gb=min_root_ebs_size_gb,
             ami=self.master_instance.image_id,
             region=self.region)
         availability_zone = self.master_instance.placement['AvailabilityZone']
@@ -616,6 +618,7 @@ def get_or_create_flintrock_security_groups(
 
 def get_ec2_block_device_mappings(
         *,
+        min_root_ebs_size_gb: int,
         ami: str,
         region: str) -> 'List[dict]':
     """
@@ -625,7 +628,6 @@ def get_ec2_block_device_mappings(
     """
     ec2 = boto3.resource(service_name='ec2', region_name=region)
     block_device_mappings = []
-    min_root_device_size_gb = 30
 
     try:
         image = list(
@@ -643,14 +645,14 @@ def get_ec2_block_device_mappings(
         root_device = [
             device for device in image.block_device_mappings
             if device['DeviceName'] == image.root_device_name][0]
-        if root_device['Ebs']['VolumeSize'] < min_root_device_size_gb:
+        if root_device['Ebs']['VolumeSize'] < min_root_ebs_size_gb:
             root_device['Ebs'].update({
                 # Max root volume size for instance store-backed AMIs is 10 GiB.
                 # See: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-instance-store-volumes.html
                 # Though, this code is probably incorrect for instance store-backed
                 # instances anyway, since boto3 doesn't seem to let you set the size
                 # of a root instance store volume.
-                'VolumeSize': min_root_device_size_gb,
+                'VolumeSize': min_root_ebs_size_gb,
                 # gp2 is general-purpose SSD
                 'VolumeType': 'gp2'})
         del root_device['Ebs']['Encrypted']
@@ -812,6 +814,7 @@ def launch(
         user,
         security_groups,
         spot_price=None,
+        min_root_ebs_size_gb,
         vpc_id,
         subnet_id,
         instance_profile_name,
@@ -858,6 +861,7 @@ def launch(
         security_group_names=security_groups)
     security_group_ids = [sg.id for sg in user_security_groups + flintrock_security_groups]
     block_device_mappings = get_ec2_block_device_mappings(
+        min_root_ebs_size_gb=min_root_ebs_size_gb,
         ami=ami,
         region=region)
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -225,6 +225,7 @@ def cli(cli_context, config, provider):
               help="Additional security groups names to assign to the instances. "
                    "You can specify this option multiple times.")
 @click.option('--ec2-spot-price', type=float)
+@click.option('--ec2-min-root-ebs-size-gb', type=int, default=30)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
 @click.option('--ec2-subnet-id', default='')
 @click.option('--ec2-instance-profile-name', default='')
@@ -264,6 +265,7 @@ def launch(
         ec2_user,
         ec2_security_groups,
         ec2_spot_price,
+        ec2_min_root_ebs_size_gb,
         ec2_vpc_id,
         ec2_subnet_id,
         ec2_instance_profile_name,
@@ -355,6 +357,7 @@ def launch(
             user=ec2_user,
             security_groups=ec2_security_groups,
             spot_price=ec2_spot_price,
+            min_root_ebs_size_gb=ec2_min_root_ebs_size_gb,
             vpc_id=ec2_vpc_id,
             subnet_id=ec2_subnet_id,
             instance_profile_name=ec2_instance_profile_name,
@@ -625,6 +628,7 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
               help="Path to SSH .pem file for accessing nodes.")
 @click.option('--ec2-user')
 @click.option('--ec2-spot-price', type=float)
+@click.option('--ec2-min-root-ebs-size-gb', type=int, default=30)
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-tag', 'ec2_tags',
               callback=ec2.cli_validate_tags,
@@ -641,6 +645,7 @@ def add_slaves(
         ec2_identity_file,
         ec2_user,
         ec2_spot_price,
+        ec2_min_root_ebs_size_gb,
         ec2_tags,
         assume_yes):
     """
@@ -668,6 +673,7 @@ def add_slaves(
         user = ec2_user
         identity_file = ec2_identity_file
         provider_options = {
+            'min_root_ebs_size_gb': ec2_min_root_ebs_size_gb,
             'spot_price': ec2_spot_price,
             'tags': ec2_tags
         }


### PR DESCRIPTION
It was hard coded. Now it's configurable. This is useful for m4, r4, c4 machines without ephemeral disks.

Fixes #174.