### PR TITLE
Show master address and login command after launch

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -948,6 +948,8 @@ def launch(
             services=services,
             user=user,
             identity_file=identity_file)
+
+        return cluster
     except (Exception, KeyboardInterrupt) as e:
         if isinstance(e, InterruptedEC2Operation):
             cleanup_instances = e.instances

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -362,7 +362,7 @@ def launch(
         services += [spark]
 
     if provider == 'ec2':
-        return ec2.launch(
+        cluster = ec2.launch(
             cluster_name=cluster_name,
             num_slaves=num_slaves,
             services=services,
@@ -387,6 +387,9 @@ def launch(
             tags=ec2_tags)
     else:
         raise UnsupportedProviderError(provider)
+
+    print("Cluster master: {}".format(cluster.master_host))
+    print("Login with: flintrock login {}".format(cluster.name))
 
 
 def get_latest_commit(github_repository: str):


### PR DESCRIPTION
This is a belated response to a suggestion (I believe originally by @engrean) to show the master address immediately after launch to make it easy for people to find the Spark UI without having to run a separate `describe`. I originally resisted but now I think it would be useful.

I also added a brief note showing how to login to the cluster after seeing several people manually look up the master address and login using plain SSH. Did anyone else do this when they first started using Flintrock?

New output:

```
$ flintrock launch nick --no-install-spark
Launching 2 instances...
[54.89.148.191] SSH online.
[54.89.148.191] Configuring ephemeral storage...
[54.89.148.191] Installing Java 1.8...
[52.23.251.87] SSH online.
[52.23.251.87] Configuring ephemeral storage...
[52.23.251.87] Installing Java 1.8...
launch finished in 0:02:49.
Cluster master: ec2-52-23-251-87.compute-1.amazonaws.com
Login with: flintrock login nick
```

It's not the cleanest output honestly, but it's practical and will do fine until we get around to #27.