### PR TITLE
User templates for hadoop / spark

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -9,12 +9,22 @@ services:
     #   - must be a tar.gz file
     # download-source: "https://www.example.com/files/spark/{v}/spark-{v}.tar.gz"
     # executor-instances: 1
+    # template-dir: # folder containing spark configuration files:
+    #   - slaves
+    #   - spark-env.sh
+    #   - spark-defaults.conf
   hdfs:
     version: 2.7.3
     # optional; defaults to download from a dynamically selected Apache mirror
     #   - must contain a {v} template corresponding to the version
     #   - must be a .tar.gz file
     # download-source: "https://www.example.com/files/hadoop/{v}/hadoop-{v}.tar.gz"
+    # template-dir: # path to the folder containing the hadoop configuration files
+    #   - masters
+    #   - slaves
+    #   - hadoop-env.sh
+    #   - hdfs-site.xml
+    #   - core-site.xml
 
 provider: ec2
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -218,6 +218,7 @@ def cli(cli_context, config, provider, debug):
               help="URL to download Hadoop from.",
               default='http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json',
               show_default=True)
+@click.option('--hdfs-config-path')
 @click.option('--install-spark/--no-install-spark', default=True)
 @click.option('--spark-executor-instances', default=1,
               help="How many executor instances per worker.")
@@ -239,6 +240,7 @@ def cli(cli_context, config, provider, debug):
               help="Git repository to clone Spark from.",
               default='https://github.com/apache/spark',
               show_default=True)
+@click.option('--spark-config-path')
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-key-name')
 @click.option('--ec2-identity-file',
@@ -281,12 +283,14 @@ def launch(
         install_hdfs,
         hdfs_version,
         hdfs_download_source,
+        hdfs_config_path,
         install_spark,
         spark_executor_instances,
         spark_version,
         spark_git_commit,
         spark_git_repository,
         spark_download_source,
+        spark_config_path,
         assume_yes,
         ec2_key_name,
         ec2_identity_file,
@@ -351,7 +355,9 @@ def launch(
     check_external_dependency('ssh-keygen')
 
     if install_hdfs:
-        hdfs = HDFS(version=hdfs_version, download_source=hdfs_download_source)
+        hdfs = HDFS(version=hdfs_version,
+                    download_source=hdfs_download_source,
+                    config_path=hdfs_config_path)
         services += [hdfs]
     if install_spark:
         if spark_version:
@@ -360,6 +366,7 @@ def launch(
                 version=spark_version,
                 hadoop_version=hdfs_version,
                 download_source=spark_download_source,
+                config_path=spark_config_path
             )
         elif spark_git_commit:
             logger.warning(
@@ -373,6 +380,7 @@ def launch(
                 git_commit=spark_git_commit,
                 git_repository=spark_git_repository,
                 hadoop_version=hdfs_version,
+                config_path=spark_config_path
             )
         services += [spark]
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -355,9 +355,11 @@ def launch(
     check_external_dependency('ssh-keygen')
 
     if install_hdfs:
-        hdfs = HDFS(version=hdfs_version,
-                    download_source=hdfs_download_source,
-                    template_dir=hdfs_template_dir)
+        hdfs = HDFS(
+            version=hdfs_version,
+            download_source=hdfs_download_source,
+            template_dir=hdfs_template_dir
+        )
         services += [hdfs]
     if install_spark:
         if spark_version:

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -218,7 +218,7 @@ def cli(cli_context, config, provider, debug):
               help="URL to download Hadoop from.",
               default='http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json',
               show_default=True)
-@click.option('--hdfs-config-path')
+@click.option('--hdfs-template-dir')
 @click.option('--install-spark/--no-install-spark', default=True)
 @click.option('--spark-executor-instances', default=1,
               help="How many executor instances per worker.")
@@ -240,7 +240,7 @@ def cli(cli_context, config, provider, debug):
               help="Git repository to clone Spark from.",
               default='https://github.com/apache/spark',
               show_default=True)
-@click.option('--spark-config-path')
+@click.option('--spark-template-dir')
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-key-name')
 @click.option('--ec2-identity-file',
@@ -283,14 +283,14 @@ def launch(
         install_hdfs,
         hdfs_version,
         hdfs_download_source,
-        hdfs_config_path,
+        hdfs_template_dir,
         install_spark,
         spark_executor_instances,
         spark_version,
         spark_git_commit,
         spark_git_repository,
         spark_download_source,
-        spark_config_path,
+        spark_template_dir,
         assume_yes,
         ec2_key_name,
         ec2_identity_file,
@@ -357,7 +357,7 @@ def launch(
     if install_hdfs:
         hdfs = HDFS(version=hdfs_version,
                     download_source=hdfs_download_source,
-                    config_path=hdfs_config_path)
+                    template_dir=hdfs_template_dir)
         services += [hdfs]
     if install_spark:
         if spark_version:
@@ -366,7 +366,7 @@ def launch(
                 version=spark_version,
                 hadoop_version=hdfs_version,
                 download_source=spark_download_source,
-                config_path=spark_config_path
+                template_dir=spark_template_dir
             )
         elif spark_git_commit:
             logger.warning(
@@ -380,7 +380,7 @@ def launch(
                 git_commit=spark_git_commit,
                 git_repository=spark_git_repository,
                 hadoop_version=hdfs_version,
-                config_path=spark_config_path
+                template_dir=spark_template_dir
             )
         services += [spark]
 

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -179,7 +179,7 @@ class HDFS(FlintrockService):
                                 spark_version='',
                                 spark_executor_instances=0,
                             ))),
-                    p=shlex.quote(template_path)))
+                    p=shlex.quote(os.path.join("hadoop/conf/",template_path))))
 
     # TODO: Convert this into start_master() and split master- or slave-specific
     #       stuff out of configure() into configure_master() and configure_slave().
@@ -342,7 +342,7 @@ class Spark(FlintrockService):
                                 hadoop_version=self.hadoop_version,
                                 spark_version=self.version or self.git_commit,
                             ))),
-                    p=shlex.quote(template_path)))
+                    p=shlex.quote(os.path.join("spark/conf/", template_path))))
 
     # TODO: Convert this into start_master() and split master- or slave-specific
     #       stuff out of configure() into configure_master() and configure_slave().

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -179,7 +179,7 @@ class HDFS(FlintrockService):
                                 spark_version='',
                                 spark_executor_instances=0,
                             ))),
-                    p=shlex.quote(os.path.join("hadoop/conf/",template_path))))
+                    p=shlex.quote(os.path.join("hadoop/conf/", template_path))))
 
     # TODO: Convert this into start_master() and split master- or slave-specific
     #       stuff out of configure() into configure_master() and configure_slave().

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -111,7 +111,10 @@ class HDFS(FlintrockService):
         self.version = version
         self.download_source = download_source
         self.template_dir = template_dir
-        self.manifest = {'version': version, 'download_source': download_source}
+        self.manifest = {
+            'version': version,
+            'download_source': download_source,
+            'template_dir': template_dir}
 
     def install(
             self,
@@ -246,6 +249,7 @@ class Spark(FlintrockService):
             'spark_executor_instances': spark_executor_instances,
             'hadoop_version': hadoop_version,
             'download_source': download_source,
+            'template_dir': template_dir,
             'git_commit': git_commit,
             'git_repository': git_repository}
 

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -107,10 +107,10 @@ class FlintrockService:
 
 
 class HDFS(FlintrockService):
-    def __init__(self, *, version, download_source, config_path):
+    def __init__(self, *, version, download_source, template_dir):
         self.version = version
         self.download_source = download_source
-        self.config_path = config_path
+        self.template_dir = template_dir
         self.manifest = {'version': version, 'download_source': download_source}
 
     def install(
@@ -158,9 +158,9 @@ class HDFS(FlintrockService):
         ]
 
         # TODO: throw error if config folder / file can't be found
-        config_dir = self.config_path
-        if config_dir is None:
-            config_dir = os.path.join(THIS_DIR, "templates/hadoop/conf")
+        template_dir = self.template_dir
+        if template_dir is None:
+            template_dir = os.path.join(THIS_DIR, "templates/hadoop/conf")
 
         for template_path in template_paths:
             ssh_check_output(
@@ -170,7 +170,7 @@ class HDFS(FlintrockService):
                 """.format(
                     f=shlex.quote(
                         get_formatted_template(
-                            path=os.path.join(config_dir, template_path),
+                            path=os.path.join(template_dir, template_path),
                             mapping=generate_template_mapping(
                                 cluster=cluster,
                                 hadoop_version=self.version,
@@ -223,7 +223,7 @@ class Spark(FlintrockService):
         version: str=None,
         hadoop_version: str,
         download_source: str=None,
-        config_path: str=None,
+        template_dir: str=None,
         git_commit: str=None,
         git_repository: str=None
     ):
@@ -237,7 +237,7 @@ class Spark(FlintrockService):
         self.version = version
         self.hadoop_version = hadoop_version
         self.download_source = download_source
-        self.config_path = config_path
+        self.template_dir = template_dir
         self.git_commit = git_commit
         self.git_repository = git_repository
 
@@ -323,9 +323,9 @@ class Spark(FlintrockService):
             'spark-defaults.conf',
         ]
 
-        config_dir = self.config_path
-        if config_dir is None:
-            config_dir = os.path.join(THIS_DIR, "templates/spark/conf")
+        template_dir = self.template_dir
+        if template_dir is None:
+            template_dir = os.path.join(THIS_DIR, "templates/spark/conf")
 
         for template_path in template_paths:
             ssh_check_output(
@@ -335,7 +335,7 @@ class Spark(FlintrockService):
                 """.format(
                     f=shlex.quote(
                         get_formatted_template(
-                            path=os.path.join(config_dir, template_path),
+                            path=os.path.join(template_dir, template_path),
                             mapping=generate_template_mapping(
                                 cluster=cluster,
                                 spark_executor_instances=self.spark_executor_instances,


### PR DESCRIPTION
This PR makes the following changes:
* add a field in the the configuration file to allow user to use his own templates for hadoop / spark

I manually tested this PR. 
I started to run `pytest` but encountered errors not related to my changes. test_static are okay
I will run the full test set once the general direction of this PR is approved.

I was thinking of adding a `flintrock generate-templates /path/to/folder` command to provide the base templates (those bundled with Flintrock). What do you think?

Fixes #200