### PR TITLE
Automatically restart Spark and HDFS master a few times if there is an issue starting them up

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -15,6 +15,7 @@ services:
     #   - must contain a {v} template corresponding to the version
     #   - must be a .tar.gz file
     # download-source: "https://www.example.com/files/hadoop/{v}/hadoop-{v}.tar.gz"
+    # download-source: "http://www-us.apache.org/dist/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz"
 
 provider: ec2
 

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -5,7 +5,6 @@ import os
 import posixpath
 import shlex
 import sys
-import time
 import logging
 from concurrent.futures import FIRST_EXCEPTION
 

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -234,14 +234,6 @@ class FlintrockCluster:
 
         run_against_hosts(partial_func=partial_func, hosts=hosts)
 
-        # EC2 seems to require a good wait here so that certain parts
-        # of the network stack are up and configured. Otherwise, we
-        # hit these issues:
-        #  * https://github.com/nchammas/flintrock/issues/129
-        #  * https://github.com/nchammas/flintrock/issues/157
-        if self.services:
-            time.sleep(30)
-
         master_ssh_client = get_ssh_client(
             user=user,
             host=self.master_ip,
@@ -252,12 +244,6 @@ class FlintrockCluster:
                 service.configure_master(
                     ssh_client=master_ssh_client,
                     cluster=self)
-
-        # NOTE: We sleep here so that the slave services have time to come up.
-        #       If we refactor stuff to have a start_slave() that blocks until
-        #       the slave is fully up, then we won't need this sleep anymore.
-        if self.services:
-            time.sleep(15)
 
         for service in self.services:
             service.health_check(master_host=self.master_ip)
@@ -632,10 +618,6 @@ def provision_cluster(
 
     run_against_hosts(partial_func=partial_func, hosts=hosts)
 
-    # For: https://github.com/nchammas/flintrock/issues/129
-    if services:
-        time.sleep(20)
-
     master_ssh_client = get_ssh_client(
         user=user,
         host=cluster.master_host,
@@ -661,12 +643,6 @@ def provision_cluster(
             service.configure_master(
                 ssh_client=master_ssh_client,
                 cluster=cluster)
-
-    # NOTE: We sleep here so that the slave services have time to come up.
-    #       If we refactor stuff to have a start_slave() that blocks until
-    #       the slave is fully up, then we won't need this sleep anymore.
-    if services:
-        time.sleep(20)
 
     for service in services:
         service.health_check(master_host=cluster.master_host)

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -193,7 +193,7 @@ class HDFS(FlintrockService):
             """)
 
         # This loop is a band-aid for: https://github.com/nchammas/flintrock/issues/157
-        attempt_limit = 10
+        attempt_limit = 3
         for attempt in range(attempt_limit):
             try:
                 ssh_check_output(
@@ -372,7 +372,7 @@ class Spark(FlintrockService):
         logger.info("[{h}] Configuring Spark master...".format(h=host))
 
         # This loop is a band-aid for: https://github.com/nchammas/flintrock/issues/129
-        attempt_limit = 10
+        attempt_limit = 3
         for attempt in range(attempt_limit):
             try:
                 ssh_check_output(

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -199,6 +199,7 @@ class HDFS(FlintrockService):
                 ssh_check_output(
                     client=ssh_client,
                     command="""
+                        ./hadoop/sbin/stop-dfs.sh
                         ./hadoop/sbin/start-dfs.sh
 
                         master_ui_response_code=0
@@ -214,7 +215,7 @@ class HDFS(FlintrockService):
                 )
                 break
             except socket.timeout as e:
-                logger.warning(
+                logger.debug(
                     "Timed out waiting for HDFS master to come up.{}"
                     .format(" Trying again..." if attempt < attempt_limit - 1 else "")
                 )
@@ -395,7 +396,7 @@ class Spark(FlintrockService):
                 )
                 break
             except socket.timeout as e:
-                logger.warning(
+                logger.debug(
                     "Timed out waiting for Spark master to come up.{}"
                     .format(" Trying again..." if attempt < attempt_limit - 1 else "")
                 )

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -189,10 +189,11 @@ class HDFS(FlintrockService):
         ssh_check_output(
             client=ssh_client,
             command="""
-                # `|| true` because on restart this command will fail.
+                # `|| true` because on cluster restart this command will fail.
                 ./hadoop/bin/hdfs namenode -format -nonInteractive || true
             """)
 
+        # This loop is a band-aid for: https://github.com/nchammas/flintrock/issues/157
         attempt_limit = 3
         for attempt in range(attempt_limit):
             try:

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -194,7 +194,7 @@ class HDFS(FlintrockService):
             """)
 
         # This loop is a band-aid for: https://github.com/nchammas/flintrock/issues/157
-        attempt_limit = 3
+        attempt_limit = 10
         for attempt in range(attempt_limit):
             try:
                 ssh_check_output(
@@ -374,7 +374,7 @@ class Spark(FlintrockService):
         logger.info("[{h}] Configuring Spark master...".format(h=host))
 
         # This loop is a band-aid for: https://github.com/nchammas/flintrock/issues/129
-        attempt_limit = 3
+        attempt_limit = 10
         for attempt in range(attempt_limit):
             try:
                 ssh_check_output(

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -3,7 +3,6 @@ import os
 import shlex
 import socket
 import sys
-import textwrap
 import urllib.error
 import urllib.request
 import logging
@@ -234,10 +233,9 @@ class HDFS(FlintrockService):
                 .urlopen(hdfs_master_ui)
                 .read()
                 .decode('utf-8'))
+            logger.info("HDFS online.")
         except Exception as e:
             raise Exception("HDFS health check failed.") from e
-
-        logger.info("HDFS online.")
 
 
 class Spark(FlintrockService):
@@ -408,24 +406,16 @@ class Spark(FlintrockService):
         spark_master_ui = 'http://{m}:8080/json/'.format(m=master_host)
 
         try:
-            spark_ui_info = json.loads(
-                urllib.request.urlopen(spark_master_ui).read().decode('utf-8'))
+            json.loads(
+                urllib.request
+                .urlopen(spark_master_ui)
+                .read()
+                .decode('utf-8')
+            )
+            # TODO: Don't print here. Return this and let the caller print.
+            logger.info("Spark online.")
         except Exception as e:
             # TODO: Catch a more specific problem known to be related to Spark not
             #       being up; provide a slightly better error message, and don't
             #       dump a large stack trace on the user.
             raise Exception("Spark health check failed.") from e
-
-        # TODO: Don't print here. Return this and let the caller print.
-        logger.info(textwrap.dedent(
-            """\
-            Spark Health Report:
-              * Master: {status}
-              * Workers: {workers}
-              * Cores: {cores}
-              * Memory: {memory:.1f} GB\
-            """.format(
-                status=spark_ui_info['status'],
-                workers=len(spark_ui_info['workers']),
-                cores=spark_ui_info['cores'],
-                memory=spark_ui_info['memory'] / 1024)))

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -1,4 +1,5 @@
 import json
+import errno
 import os
 import shlex
 import socket
@@ -208,11 +209,11 @@ class HDFS(FlintrockService):
                     .read()
                     .decode('utf-8'))
                 break
-            except urllib.error.HTTPError as e:
-                if e.errno == 61:
+            except urllib.error.URLError as e:
+                if e.errno == errno.ECONNREFUSED:
                     if attempt < attempt_limit - 1:
                         waiting = " Waiting..."
-                        sleep_for = 120
+                        sleep_for = 30
                     else:
                         waiting = ""
                         sleep_for = 0

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -189,6 +189,7 @@ class HDFS(FlintrockService):
         ssh_check_output(
             client=ssh_client,
             command="""
+                # `|| true` because on restart this command will fail.
                 ./hadoop/bin/hdfs namenode -format -nonInteractive || true
             """)
 

--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -104,14 +104,21 @@ def get_ssh_client(
     return client
 
 
-def ssh_check_output(client: paramiko.client.SSHClient, command: str):
+def ssh_check_output(
+        client: paramiko.client.SSHClient,
+        command: str,
+        timeout_seconds: int=None,
+    ):
     """
     Run a command via the provided SSH client and return the output captured
     on stdout.
 
     Raise an exception if the command returns a non-zero code.
     """
-    stdin, stdout, stderr = client.exec_command(command, get_pty=True)
+    stdin, stdout, stderr = client.exec_command(
+        command,
+        get_pty=True,
+        timeout=timeout_seconds)
 
     # NOTE: Paramiko doesn't clearly document this, but we must read() before
     #       calling recv_exit_status().

--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -108,7 +108,7 @@ def ssh_check_output(
         client: paramiko.client.SSHClient,
         command: str,
         timeout_seconds: int=None,
-    ):
+):
     """
     Run a command via the provided SSH client and return the output captured
     on stdout.


### PR DESCRIPTION
This PR band-aids a couple of related issues that have plagued Flintrock for a while: Spark and HDFS sometimes get stuck on master startup, especially after a cluster restart.

The issue is somehow related to EC2's network stack, but I don't have any solid leads on the root cause. Instead, I've implemented a good-enough workaround that finally gets the full acceptance suite passing on first try. It's been a while since I've been able to do that.

TODO:
- [ ] ~Abstract out repeated retry logic across HDFS and Spark (?)~
- [x] Try removing waits added in #160

This is probably as good a solution as I'm going to find for now, so I'm marking this PR as a fix for these two issues:

Fixes #129.
Fixes #157.
