### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
     author='Nicholas Chammas',
     author_email='nicholas.chammas@gmail.com',
     license='Apache License 2.0',
+    python_requires='>= 3.4',
 
     # See: https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[


### PR DESCRIPTION
As recommended [here](http://www.python3statement.org/practicalities/). Makes pip install fail right away if user is on Python < 3.4, which is what we want.