### PR TITLE
Upgrade PyInstaller + mark tests that require AWS credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: python
 python:
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - "pip install -r requirements/developer.pip"
-  - "curl -L -o pandoc.deb https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb && sudo dpkg -i pandoc.deb"
+  - "curl -L -o pandoc.deb https://github.com/jgm/pandoc/releases/download/2.0.1.1/pandoc-2.0.1.1-1-amd64.deb && sudo dpkg -i pandoc.deb"
 script:
   - "py.test ./tests/test_static.py"
   - "py.test ./tests/test_flintrock.py"

--- a/generate-standalone-package.py
+++ b/generate-standalone-package.py
@@ -24,6 +24,10 @@ if __name__ == '__main__':
             # We won't need this when this issue is resolved:
             # https://github.com/pyinstaller/pyinstaller/issues/1844
             '--hidden-import', 'html.parser',
+            # This hidden import is also introduced by botocore.
+            # It appears to be related to this issue:
+            # https://github.com/pyinstaller/pyinstaller/issues/1935
+            '--hidden-import', 'configparser',
             'standalone.py'
         ],
         check=True)

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -2,4 +2,4 @@
 wheel >= 0.30.0
 twine >= 1.9.1
 pypandoc >= 1.4
-PyInstaller == 3.2
+PyInstaller == 3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 norecursedirs = venv
-addopts = --verbose --cov flintrock --cov-report html
+addopts = --verbose --cov flintrock --cov-report html -rs
 
 [flake8]
 max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     keywords=['Apache Spark'],
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,35 +9,27 @@ The instructions here assume the following things:
 3. You're running Python 3.5+.
 4. You've already setup your Flintrock config file and can launch clusters.
 
-
-## Run All Tests
-
-To run all of Flintrock's tests, just run:
+To run all of Flintrock's tests that don't require AWS credentials, just run:
 
 ```sh
 pytest
 ```
 
-Keep in mind that the complete test run is quite long, as **it involves launching real clusters which cost real money**.
+This is probably what you want to do most of the time.
 
-
-## Static Analysis
-
-These tests will make sure your code compiles, check for style issues, and look for other potential problems that can be detected without running Flintrock "for real".
+To run all of Flintrock's tests, including the ones that require AWS credentials (like acceptance tests), run this:
 
 ```sh
-pytest tests/test_static.py
+USE_AWS_CREDENTIALS=true pytest  # will launch real clusters!
 ```
 
+Acceptance tests launch and manipulate real clusters to test Flintrock's various commands and make sure installed services like Spark are working correctly.
 
-## Acceptance Tests
+Some things you should keep in mind when running the full test suite with your AWS credentials:
 
-These tests launch and manipulate real clusters to test Flintrock's various commands and make sure installed services like Spark are working correctly.
+  * **Running the full test suite costs money** (less than $1 for the full test run) since it launches and manipulates real clusters.
+  * **A failed test run may leave behind running clusters**. You'll need to destroy these manually.
+  * The full test suite takes a while to run (~30-60 minutes).
+  * Though the tests that use your AWS credentials are disabled by default, you can explicitly disable them by setting `USE_AWS_CREDENTIALS=""`. Setting that variable to `false` or to any non-empty string won't work.
 
-```sh
-pytest tests/test_acceptance.py
-```
-
-Acceptance tests are the most valuable type of test for an orchestration tool like Flintrock, but they also **cost money** (less than $1 for the full test run) and take a while to run (~30-60 minutes). Use them judiciously.
-
-Note that **a failed test run may leave behind running clusters**. You'll need to delete these manually.
+Relatively speaking, acceptance tests are expensive, but they are the most valuable type of test for an orchestration tool like Flintrock. Use them judiciously.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,12 @@ class Dummy():
     pass
 
 
+aws_credentials_required = (
+    pytest.mark.skipif(
+        not bool(os.environ.get('USE_AWS_CREDENTIALS')),
+        reason="USE_AWS_CREDENTIALS not set"))
+
+
 @pytest.fixture(scope='session')
 def dummy_cluster():
     storage_dirs = StorageDirs(

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -4,6 +4,9 @@ import urllib.request
 
 # Flintrock modules
 from flintrock.exceptions import ClusterInvalidState
+from conftest import aws_credentials_required
+
+pytestmark = aws_credentials_required
 
 
 def test_describe_stopped_cluster(stopped_cluster):

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -4,6 +4,8 @@ import shutil
 import subprocess
 import sys
 
+from conftest import aws_credentials_required
+
 # External modules
 import pytest
 
@@ -46,6 +48,7 @@ def test_pyinstaller_flintrock_help(pyinstaller_flintrock):
 
 @pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ is required")
 @pytest.mark.skipif(not pyinstaller_exists(), reason="PyInstaller is required")
+@aws_credentials_required
 def test_pyinstaller_flintrock_describe(pyinstaller_flintrock):
     # This test picks up some PyInstaller packaging issues that are not
     # exposed by the help test.

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -1,4 +1,5 @@
 import glob
+import os
 import shutil
 import subprocess
 import sys
@@ -11,20 +12,52 @@ def pyinstaller_exists():
     return shutil.which('pyinstaller') is not None
 
 
+# PyTest doesn't let you place skipif markers on fixures. Otherwise,
+# we'd ideally be able to do that and all the dependent tests would be
+# skipped automatically.
+@pytest.fixture(scope='session')
+def pyinstaller_flintrock():
+    flintrock_executable_path = './dist/flintrock/flintrock'
+    p = subprocess.run([
+        'python', 'generate-standalone-package.py'
+    ])
+    assert p.returncode == 0
+    assert glob.glob('./dist/*.zip')
+    assert os.path.isfile(flintrock_executable_path)
+    return flintrock_executable_path
+
+
 @pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ is required")
 @pytest.mark.skipif(not pyinstaller_exists(), reason="PyInstaller is required")
-def test_pyinstaller_packaging():
-    subprocess.run(
-        ['python', 'generate-standalone-package.py'],
-        check=True)
-    subprocess.run(
+def test_pyinstaller_flintrock_help(pyinstaller_flintrock):
+    p = subprocess.run(
         # Without explicitly setting the locale here, Click will complain
         # when this test is run via GitHub Desktop that the locale is
         # misconfigured.
         """
         export LANG=en_US.UTF-8
-        ./dist/flintrock/flintrock
-        """,
-        shell=True,
-        check=True)
-    assert glob.glob('./dist/*.zip')
+        {flintrock_executable}
+        """.format(
+            flintrock_executable=pyinstaller_flintrock
+        ),
+        shell=True)
+    assert p.returncode == 0
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ is required")
+@pytest.mark.skipif(not pyinstaller_exists(), reason="PyInstaller is required")
+def test_pyinstaller_flintrock_describe(pyinstaller_flintrock):
+    # This test picks up some PyInstaller packaging issues that are not
+    # exposed by the help test.
+    p = subprocess.run(
+        # Without explicitly setting the locale here, Click will complain
+        # when this test is run via GitHub Desktop that the locale is
+        # misconfigured.
+        """
+        export LANG=en_US.UTF-8
+        {flintrock_executable} describe
+        """.format(
+            flintrock_executable=pyinstaller_flintrock,
+        ),
+        shell=True)
+    assert p.returncode == 0


### PR DESCRIPTION
PyInstaller was the only thing that was holding me back from adding the Python 3.6 classifier (Flintrock otherwise worked with Python 3.6 just fine). That should be fixed now.

This PR also marks the tests that require AWS credentials and makes it easier to skip or include them as desired.