### PR TITLE
Set default HDFS version and add related option dependency

### DIFF
--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -329,6 +329,11 @@ def launch(
             '--spark-git-commit'],
         scope=locals())
     option_requires(
+        option='--install-spark',
+        requires_all=[
+            '--hdfs-version'],
+        scope=locals())
+    option_requires(
         option='--provider',
         conditional_value='ec2',
         requires_all=[

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -208,12 +208,7 @@ def cli(cli_context, config, provider, debug):
 @click.argument('cluster-name')
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
-@click.option('--hdfs-version',
-              # Don't set a default here because it may conflict with
-              # the config file.
-              # See: https://github.com/nchammas/flintrock/issues/190
-              # default=
-              )
+@click.option('--hdfs-version', default='2.7.4')
 @click.option('--hdfs-download-source',
               help="URL to download Hadoop from.",
               default='http://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz?as_json',
@@ -222,8 +217,8 @@ def cli(cli_context, config, provider, debug):
 @click.option('--spark-executor-instances', default=1,
               help="How many executor instances per worker.")
 @click.option('--spark-version',
-              # Don't set a default here because it may conflict with
-              # the config file.
+              # Don't set a default here because it will conflict with
+              # the config file if the git commit is set.
               # See: https://github.com/nchammas/flintrock/issues/190
               # default=,
               help="Spark release version to install.")


### PR DESCRIPTION
So that launches that do not explicitly specify the Hadoop/HDFS version still work.

TODO:
- [x] Confirm that the README sample config works as expected.
- [x] Confirm that the README sample invocation of Flintrock without config works as expected.

Fixes #220.
