### PR TITLE
Wait for terminated state while destroying a cluster

### DIFF
--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -437,8 +437,9 @@ def get_latest_commit(github_repository: str):
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
+@click.option('--no-wait', default=False)
 @click.pass_context
-def destroy(cli_context, cluster_name, assume_yes, ec2_region, ec2_vpc_id):
+def destroy(cli_context, cluster_name, assume_yes, ec2_region, ec2_vpc_id, no_wait):
     """
     Destroy a cluster.
     """
@@ -466,6 +467,9 @@ def destroy(cli_context, cluster_name, assume_yes, ec2_region, ec2_vpc_id):
 
     logger.info("Destroying {c}...".format(c=cluster.name))
     cluster.destroy()
+
+    if not no_wait:
+        cluster.wait_for_state('terminated')
 
 
 @cli.command()


### PR DESCRIPTION
This PR makes the following changes:
* Add `--no-wait` option to `destroy` command with False default
* `destroy` command waits for instances to be in "terminated" state  `cluster.wait_for_state('terminated') `

I tested this PR by manually launching and destroying clusters. I'm not sure about tests for this, should I add one to cover `--no-wait` option?

Fixes #229 
