### PR TITLE
Wait for terminated state while destroying a cluster

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -179,6 +179,7 @@ class EC2Cluster(FlintrockCluster):
                     {'Name': 'instance-id', 'Values': [i.id for i in self.instances]}
                 ])
             .terminate())
+        self.wait_for_state('terminated')
 
     def start_check(self):
         if self.state == 'running':


### PR DESCRIPTION
This PR makes the following changes:
* destroy command waits for the instances to be in "terminated" state via `cluster.wait_for_state('terminated')`

Fixes #229