### PR TITLE
Set default number of SSH tries > 1

### DIFF
--- a/flintrock/ssh.py
+++ b/flintrock/ssh.py
@@ -69,7 +69,9 @@ def get_ssh_client(
     if wait:
         tries = 100
     else:
-        tries = 1
+        # It's greater than 1 as a band-aid for this issue:
+        # https://github.com/nchammas/flintrock/issues/198
+        tries = 3
 
     while tries > 0:
         try:


### PR DESCRIPTION
cc @pragnesh and @steve-drew-strong-bridge.

If we can get away with 3 tries I'd prefer that, but you let me know if 5 tries is what's needed to avoid this issue. I don't see it so I'll need your feedback here.

Prompted by #198.
