### PR TITLE
Mention Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ pip3 install flintrock
 
 This will install Flintrock and place it on your path. You should be good to go now!
 
-If you use [Homebrew](https://brew.sh), you can `brew install flintrock` instead.
-
 You'll probably want to get started with the following two commands:
 
 ```sh
@@ -139,6 +137,17 @@ cd flintrock/
 
 You'll probably want to add the location of the Flintrock executable to your `PATH` so that you
 can invoke it from any directory.
+
+### Community-supported distributions
+
+Flintrock may be available in your favorite package manager!
+These packages are not supported by the core contributors and may be out of date.
+Please reach out to these communities directly if you have trouble using them to install flintrock.
+
+These include:
+
+ * [Homebrew](https://brew.sh): `brew install flintrock`
+
 
 ### Development version
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ pip3 install flintrock
 
 This will install Flintrock and place it on your path. You should be good to go now!
 
+If you use [Homebrew](https://brew.sh), you can `brew install flintrock` instead.
+
 You'll probably want to get started with the following two commands:
 
 ```sh


### PR DESCRIPTION
Hi; thanks for flintrock! I packaged flintrock for Homebrew if you'd like to mention it in the readme. The advantage of installing with Homebrew is that it keeps flintrock and its dependencies in its own private virtualenv, and users can get new versions when they run `brew upgrade`.