### PR TITLE
Add links to new flintrock guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Flintrock has been featured in a few talks, guides, and papers around the web.
 * Talks:
   * [Flintrock: A faster, better spark-ec2](https://www.youtube.com/watch?v=3aeIpOGrJOA) ([slides](http://www.slideshare.net/SparkSummit/flintrock-a-faster-better-sparkec2-by-nicholas-chammas))
 * Guides:
+  * **Running Spark on a Cluster: The Basics (using flintrock)**
+    * [Part 1: Start a Spark Cluster and Use the spark-shell](http://heather.miller.am/blog/launching-a-spark-cluster-part-1.html)
+    * [Part 2: Dependencies, S3, and Deploying via spark-submit](http://heather.miller.am/blog/launching-a-spark-cluster-part-2.html)    
   * [Spark with Jupyter on AWS](https://github.com/PiercingDan/spark-Jupyter-AWS)
   * [Building a data science platform for R&D, part 2 – Deploying Spark on AWS using Flintrock](https://alexioannides.com/2016/08/18/building-a-data-science-platform-for-rd-part-2-deploying-spark-on-aws-using-flintrock/)
   * [AWS EC2를 활용 스파크 클러스터 생성](http://statkclee.github.io/ml/ml-aws-ec2-flintrock.html)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Flintrock has been featured in a few talks, guides, and papers around the web.
 * Talks:
   * [Flintrock: A faster, better spark-ec2](https://www.youtube.com/watch?v=3aeIpOGrJOA) ([slides](http://www.slideshare.net/SparkSummit/flintrock-a-faster-better-sparkec2-by-nicholas-chammas))
 * Guides:
-  * **Running Spark on a Cluster: The Basics (using flintrock)**
+  * Running Spark on a Cluster: The Basics (using Flintrock)
     * [Part 1: Start a Spark Cluster and Use the spark-shell](http://heather.miller.am/blog/launching-a-spark-cluster-part-1.html)
     * [Part 2: Dependencies, S3, and Deploying via spark-submit](http://heather.miller.am/blog/launching-a-spark-cluster-part-2.html)    
   * [Spark with Jupyter on AWS](https://github.com/PiercingDan/spark-Jupyter-AWS)


### PR DESCRIPTION
I just wrote up a guide for using flintrock to start up a Spark cluster and how to use it to submit jobs to your cluster. Have a look! Looks like it could be useful documentation for your project :)

Wonderful tool btw!