### PR TITLE
Fix some "flintrock describe" errors, using a filter on instance-state-name

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -1002,6 +1002,7 @@ def get_clusters(*, cluster_names: list=[], region: str, vpc_id: str) -> list:
     all_clusters_instances = list(
         ec2.instances.filter(
             Filters=[
+                {'Name': 'instance-state-name', 'Values': ['pending', 'running', 'stopping', 'stopped']},
                 {'Name': 'instance.group-name', 'Values': group_name_filter},
                 {'Name': 'vpc-id', 'Values': [vpc_id]},
             ]))


### PR DESCRIPTION
This PR makes the following change:
* Add a filter to ignore instances that are 'shutting-down' or 'terminated'. (actually, we can't exclude states, so we have to specify the allowed states, i.e. 'pending', 'running', 'stopping' and 'stopped')

I tested this PR by
* launching a cluster
* adding slaves
* stopping the cluster
* removing slaves
* destroying the cluster.

For each tested command, I ran "flintrock describe" using two standalone Flintrocks (one with the fix and one without).

This PR partially fixes `Exception: Could not extract cluster name from instance: when a cluster is destroyed or when slaves are removed` (#236): this exception will be raised during the first seconds instead of being raised during 30 seconds / a minute.

This PR also fixes the following error, which is raised when a cluster is launched or when slaves are added:
```
Traceback (most recent call last):
  File "standalone.py", line 11, in <module>
  File "flintrock/flintrock.py", line 1110, in main
  File "click/core.py", line 716, in __call__
  File "click/core.py", line 696, in main
  File "click/core.py", line 1060, in invoke
  File "click/core.py", line 889, in invoke
  File "click/core.py", line 534, in invoke
  File "click/decorators.py", line 17, in new_func
  File "flintrock/flintrock.py", line 477, in describe
  File "flintrock/ec2.py", line 1053, in get_clusters
  File "flintrock/ec2.py", line 1053, in <listcomp>
  File "flintrock/ec2.py", line 1104, in _compose_cluster 
  File "flintrock/ec2.py", line 1080, in _get_cluster_master_slaves
TypeError: 'NoneType' object is not iterable
```
Instead of raising this error, `flintrock describe` will now display :
```
my-cluster-name:
  state: inconsistent
  node-count: 0
```
