### PR TITLE
Move setup.py to Markdown description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - "3.6"
 install:
   - "pip install -r requirements/developer.pip"
-  - "curl -L -o pandoc.deb https://github.com/jgm/pandoc/releases/download/2.0.1.1/pandoc-2.0.1.1-1-amd64.deb && sudo dpkg -i pandoc.deb"
 script:
   - "pytest ./tests/test_static.py"
   - "pytest ./tests/test_flintrock.py"

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -1,5 +1,4 @@
 -r developer.pip
 wheel >= 0.31.0
 twine >= 1.11.0
-pypandoc >= 1.4
 PyInstaller == 3.3

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,16 @@
 import setuptools
-
-try:
-    import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
-except ImportError:
-    long_description = open('README.md').read()
-
 from flintrock import __version__
+
+
+with open('README.md') as f:
+    long_description = f.read()
 
 setuptools.setup(
     name='Flintrock',
     version=__version__,
     description='A command-line tool for launching Apache Spark clusters.',
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url='https://github.com/nchammas/flintrock',
     author='Nicholas Chammas',
     author_email='nicholas.chammas@gmail.com',


### PR DESCRIPTION
Following [the instructions here](https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi). PyPI now supports Markdown descriptions.

Goodbye Pandoc, and thanks for all the help!