### PR TITLE
Move hadoop-aws from default package to README recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ these steps:
    versions of Hadoop do not have solid implementations of `s3a://`.
    Flintrock's default is Hadoop 2.8.4, so you don't need to do anything
    here if you're using a vanilla configuration.
+4. Call Spark with the hadoop-aws package to enable `s3a://`. For example:
+   ```sh
+   spark-submit --packages org.apache.hadoop:hadoop-aws:2.7.6 my-app.py
+   pyspark --packages org.apache.hadoop:hadoop-aws:2.7.6
+   ```
+   If you have issues using the package, consult the [hadoop-aws troubleshooting
+   guide](http://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html)
+   and try adjusting the version. As a rule of thumb, you should match the version
+   of hadoop-aws to the version of Hadoop that Spark was built against (which is
+   typically Hadoop 2.7).
 
 With this approach you don't need to copy around your AWS credentials
 or pass them into your Spark programs. As long as the assigned IAM role

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ these steps:
    guide](http://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html)
    and try adjusting the version. As a rule of thumb, you should match the version
    of hadoop-aws to the version of Hadoop that Spark was built against (which is
-   typically Hadoop 2.7).
+   typically Hadoop 2.7), even if the version of Hadoop that you're deploying to
+   your Flintrock cluster is different.
 
 With this approach you don't need to copy around your AWS credentials
 or pass them into your Spark programs. As long as the assigned IAM role

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -318,7 +318,9 @@ class Spark(FlintrockService):
                 """.format(
                     repo=shlex.quote(self.git_repository),
                     commit=shlex.quote(self.git_commit),
-                    hadoop_short_version='.'.join(self.hadoop_version.split('.')[:2]),
+                    # Hardcoding this here until we figure out a better way to handle
+                    # the supported build profiles.
+                    hadoop_short_version='2.7',
                 ))
         ssh_check_output(
             client=ssh_client,

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -340,7 +340,6 @@ class Spark(FlintrockService):
         template_paths = [
             'spark/conf/spark-env.sh',
             'spark/conf/slaves',
-            'spark/conf/spark-defaults.conf',
         ]
 
         ssh_check_output(

--- a/flintrock/templates/spark/conf/spark-defaults.conf
+++ b/flintrock/templates/spark/conf/spark-defaults.conf
@@ -1,1 +1,0 @@
-spark.jars.packages    org.apache.hadoop:hadoop-aws:{hadoop_version}


### PR DESCRIPTION
Following up on @heathermiller's [comments here](https://github.com/nchammas/flintrock/pull/243#issuecomment-379272989), I think this fixes `s3a://` for folks using `spark-submit --deploy-mode cluster` from a remote client.

[It's difficult](https://issues.apache.org/jira/browse/HADOOP-15559) to come up with a completely seamless way to setup `s3a://` due to all the incompatibilities you have to work around, but I think that instructing users to use `--packages ...:hadoop-aws` is the best I can do at this time at the intersection of "easy to maintain" and "works for the user".

I don't have a Scala toolchain setup on my machine, so I couldn't directly confirm that this eliminates the need to manually copy AWS-related jars, as [described here](http://heather.miller.am/blog/launching-a-spark-cluster-part-2.html), and PySpark does not support cluster deploy mode with a standalone master, so I couldn't test it that way either. But I'd expect this to work since it works when I interactively start a PySpark shell from the master.

@heathermiller - If you have the time to test that calling `spark-submit --deploy-mode cluster --packages ...:hadoop-aws` eliminates the need to manually install hadoop-`aws-2.7.2.jar` and `aws-java-sdk-1.7.4.jar` on the cluster, that would be great. No worries otherwise.

Related to #180.