### PR TITLE
Updated PyYaml dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         'botocore == 1.10.58',
         'click == 6.7',
         'paramiko == 2.4.1',
-        'PyYAML == 3.12',
+        'PyYAML == 3.13',
         # This is to ensure that PyInstaller works. dateutil is an
         # indirect dependency of Flintrock, and PyInstaller chokes on
         # dateutil 2.5.0.


### PR DESCRIPTION
bumped up PyYaml version to version 3.13, which works under Python 3.7.0

This PR makes the following changes:

- Simply updating the PyYaml dependency in setup.py

I tested this PR by installing the resulting package and running some basic usage (launch, destroy, login, copy-file).

Fixes #267.