### PR TITLE
[#271] Properly handle multiple client IP addresses

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -489,6 +489,15 @@ def get_security_groups(
     return groups
 
 
+def _get_client_ip_address() -> str:
+    """
+    Returns a single Flintrock client's IP address using AWS "checkip" service
+    (which may return multiple addresses).
+    """
+    return (urllib.request.urlopen('http://checkip.amazonaws.com/')
+            .read().decode('utf-8').strip())
+
+
 def get_or_create_flintrock_security_groups(
         *,
         cluster_name,
@@ -540,10 +549,7 @@ def get_or_create_flintrock_security_groups(
             VpcId=vpc_id)
 
     # Rules for the client interacting with the cluster.
-    flintrock_client_ip = (
-        urllib.request.urlopen('http://checkip.amazonaws.com/')
-        .read().decode('utf-8').strip())
-    flintrock_client_cidr = '{ip}/32'.format(ip=flintrock_client_ip)
+    flintrock_client_cidr = '{ip}/32'.format(ip=_get_client_ip_address())
 
     # TODO: Services should be responsible for registering what ports they want exposed.
     client_rules = [

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -495,7 +495,9 @@ def _get_client_ip_address() -> str:
     (which may return multiple addresses).
     """
     return (urllib.request.urlopen('http://checkip.amazonaws.com/')
-            .read().decode('utf-8').strip())
+            .read().decode('utf-8')
+            .split(',')[0]
+            .strip())
 
 
 def get_or_create_flintrock_security_groups(

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -42,11 +42,9 @@ def test_client_ip_address(monkeypatch):
         monkeypatch.setattr(ec2.urllib.request, 'urlopen',
                             lambda url: request_obj)
 
-    # Mocking urllib to make the request to AWS service "checkip" return
-    # multiple IP addresses.
+    # Vide issue 271: https://github.com/nchammas/flintrock/issues/271
     mock_checkip('189.4.79.64, 107.167.109.191\n')
     assert ec2._get_client_ip_address() == '189.4.79.64'
 
-    # Checking the most common case, a single IP address.
     mock_checkip('189.4.79.64\n')
     assert ec2._get_client_ip_address() == '189.4.79.64'


### PR DESCRIPTION
This PR makes the following changes:
* it adds a call to `split(',')` from the string returned by AWS "checkip".

I tested this PR by adding a unit test for the function responsible for making the HTTP request to "checkip". The acceptance tests were not executed.

Fixes #271 