### PR TITLE
[#271] Avoid multiple client IP addresses by using HTTPS

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -541,7 +541,7 @@ def get_or_create_flintrock_security_groups(
 
     # Rules for the client interacting with the cluster.
     flintrock_client_ip = (
-        urllib.request.urlopen('http://checkip.amazonaws.com/')
+        urllib.request.urlopen('https://checkip.amazonaws.com/')
         .read().decode('utf-8').strip())
     flintrock_client_cidr = '{ip}/32'.format(ip=flintrock_client_ip)
 


### PR DESCRIPTION
This PR makes the following changes:
* replaces HTTP protocol by HTTPS when calling AWS service **checkip**

I tested this PR by calling the service from many different clients using both HTTP and HTTPS protocols.

As suggested in #272, just replacing the protocol seems to avoid the problem of receiving multiple IP addresses from **checkip**.

Fixes #271 