### PR TITLE
Simplify Travis CI script step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,9 @@ matrix:
       dist: "xenial"
       sudo: true
 install:
-  - "pip install -r requirements/developer.pip"
-script:
-  - "pytest ./tests/test_static.py"
-  - "pytest ./tests/test_flintrock.py"
-  - "pytest ./tests/test_core.py"
   - "pip install -r requirements/maintainer.pip"
-  - "pytest ./tests/test_pyinstaller_packaging.py"
+script:
+  - "pytest"
 addons:
   artifacts:
     paths:

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -25,6 +25,7 @@ def tgz_file(request):
     return tgz_file_name
 
 
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ is required")
 @pytest.mark.parametrize('python', ['python', 'python2'])
 def test_download_package(python, project_root_dir, tgz_file):
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import tempfile
 
 import pytest


### PR DESCRIPTION
The intention initially was to ensure that certain tests could run successfully without the maintainer requirements installed, which I suppose is a good goal, but in practice this setup has meant that I've missed adding new test files to the Travis CI build.

I think what I have in this PR is a better trade-off: Run the full test suite automatically so I don't have to manually update the Travis CI build, and take the small risk that I will introduce a maintainer dependency to the test suite without realizing it.