### PR TITLE
switch all worker to private dns

### DIFF
--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -441,8 +441,10 @@ def generate_template_mapping(
     template_mapping = {
         'master_ip': cluster.master_ip,
         'master_host': cluster.master_host,
+        'master_private_host': cluster.master_private_host,
         'slave_ips': '\n'.join(cluster.slave_ips),
         'slave_hosts': '\n'.join(cluster.slave_hosts),
+        'slave_private_hosts': '\n'.join(cluster.slave_private_hosts),
 
         'hadoop_version': hadoop_version,
         'hadoop_short_version': '.'.join(hadoop_version.split('.')[:2]),

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -88,12 +88,20 @@ class EC2Cluster(FlintrockCluster):
         return self.master_instance.public_dns_name
 
     @property
+    def master_private_host(self):
+        return self.master_instance.private_dns_name
+
+    @property
     def slave_ips(self):
         return [i.public_ip_address for i in self.slave_instances]
 
     @property
     def slave_hosts(self):
         return [i.public_dns_name for i in self.slave_instances]
+
+    @property
+    def slave_private_hosts(self):
+        return [i.private_dns_name for i in self.slave_instances]
 
     @property
     def num_masters(self):

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -213,7 +213,7 @@ class HDFS(FlintrockService):
                                     --write-out "%{{http_code}}" {m}:50070
                             )"
                         done
-                    """.format(m=shlex.quote(cluster.master_host)),
+                    """.format(m=shlex.quote(cluster.master_private_host)),
                     timeout_seconds=90
                 )
                 break
@@ -394,7 +394,7 @@ class Spark(FlintrockService):
                                     --write-out "%{{http_code}}" {m}:8080
                             )"
                         done
-                    """.format(m=shlex.quote(cluster.master_host)),
+                    """.format(m=shlex.quote(cluster.master_private_host)),
                     timeout_seconds=90
                 )
                 break

--- a/flintrock/templates/hadoop/conf/core-site.xml
+++ b/flintrock/templates/hadoop/conf/core-site.xml
@@ -9,6 +9,6 @@
 
   <property>
     <name>fs.defaultFS</name>
-    <value>hdfs://{master_host}:9000</value>
+    <value>hdfs://{master_private_host}:9000</value>
   </property>
 </configuration>

--- a/flintrock/templates/hadoop/conf/masters
+++ b/flintrock/templates/hadoop/conf/masters
@@ -1,1 +1,1 @@
-{master_host}
+{master_private_host}

--- a/flintrock/templates/hadoop/conf/slaves
+++ b/flintrock/templates/hadoop/conf/slaves
@@ -1,1 +1,1 @@
-{slave_hosts}
+{slave_private_hosts}

--- a/flintrock/templates/spark/conf/slaves
+++ b/flintrock/templates/spark/conf/slaves
@@ -1,1 +1,1 @@
-{slave_hosts}
+{slave_private_hosts}

--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -7,7 +7,7 @@ export SPARK_EXECUTOR_INSTANCES="{spark_executor_instances}"
 export SPARK_EXECUTOR_CORES="$(($(nproc) / {spark_executor_instances}))"
 export SPARK_WORKER_CORES="$(nproc)"
 
-export SPARK_MASTER_HOST="{master_host}"
+export SPARK_MASTER_HOST="{master_private_host}"
 
 # TODO: Make this dependent on HDFS install.
 export HADOOP_CONF_DIR="$HOME/hadoop/conf"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,10 @@ def dummy_cluster():
     cluster.storage_dirs = storage_dirs
     cluster.master_ip = '10.0.0.1'
     cluster.master_host = 'master.hostname'
+    cluster.master_private_host = 'master.privatehostname'
     cluster.slave_ips = ['10.0.0.2']
     cluster.slave_hosts = ['slave1.hostname']
+    cluster.slave_private_hosts = ['slave1.privatehostname']
 
     return cluster
 


### PR DESCRIPTION
This PR makes the following changes:

switch all worker to private dns

I tested this PR by...
launching cluster where i am seeing slow startup(flintrock needed bend-aid to start cluster).
After this change cluster start in first try.

Fixes #157.
Fixes #129.

When instance start on aws, aws update public dns host from public ip -> private ip,
This create issue with cluster communication. If you switch all worker to private dns name,
Cluster does not have any issue in starting which fix band-aid required for starting hdfs cluster and spark cluster.
