### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 # Work-around for Python 3.7 on Travis CI pulled from here:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Before using Flintrock, take a quick look at the
 notice and [license](https://github.com/nchammas/flintrock/blob/master/LICENSE)
 and make sure you're OK with their terms.
 
-**Flintrock requires Python 3.4 or newer**, unless you are using one
+**Flintrock requires Python 3.5 or newer**, unless you are using one
 of our **standalone packages**. Flintrock has been thoroughly tested
 only on OS X, but it should run on all POSIX systems.
 A motivated contributor should be able to add

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     author='Nicholas Chammas',
     author_email='nicholas.chammas@gmail.com',
     license='Apache License 2.0',
-    python_requires='>= 3.4',
+    python_requires='>= 3.5',
 
     # See: https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
@@ -33,7 +33,6 @@ setuptools.setup(
 
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Python 3.4 reached [end-of-life in March 2019](https://www.python.org/downloads/release/python-3410/). This PR removes support for it, which trims our support and testing matrix, and makes future changes simpler (like the dependency changes in #252).