### PR TITLE
Bump defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Here's a quick way to launch a cluster on EC2, assuming you already have an [AWS
 ```sh
 flintrock launch test-cluster \
     --num-slaves 1 \
-    --spark-version 2.4.3 \
+    --spark-version 2.4.4 \
     --ec2-key-name key_name \
     --ec2-identity-file /path/to/key.pem \
-    --ec2-ami ami-0b8d0d6ac70e5750c \
+    --ec2-ami ami-00b882ac5193044e4 \
     --ec2-user ec2-user
 ```
 
@@ -254,7 +254,7 @@ provider: ec2
 
 services:
   spark:
-    version: 2.4.3
+    version: 2.4.4
 
 launch:
   num-slaves: 1
@@ -263,9 +263,9 @@ providers:
   ec2:
     key-name: key_name
     identity-file: /path/to/.ssh/key.pem
-    instance-type: m3.medium
+    instance-type: m5.large
     region: us-east-1
-    ami: ami-0b8d0d6ac70e5750c
+    ami: ami-00b882ac5193044e4
     user: ec2-user
 ```
 
@@ -280,7 +280,7 @@ And if you want, you can even override individual options in your config file at
 ```sh
 flintrock launch test-cluster \
     --num-slaves 10 \
-    --ec2-instance-type r3.xlarge
+    --ec2-instance-type r5.xlarge
 ```
 
 ### Fast Launches

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -1,6 +1,6 @@
 services:
   spark:
-    version: 2.4.3
+    version: 2.4.4
     # git-commit: latest  # if not 'latest', provide a full commit SHA; e.g. d6dc12ef0146ae409834c78737c116050961f350
     # git-repository:  # optional; defaults to https://github.com/apache/spark
     # optional; defaults to download from from the official Spark S3 bucket
@@ -23,10 +23,10 @@ providers:
   ec2:
     key-name: key_name
     identity-file: /path/to/key.pem
-    instance-type: m3.medium
+    instance-type: m5.large
     region: us-east-1
     # availability-zone: <name>
-    ami: ami-0b8d0d6ac70e5750c  # Amazon Linux 2, us-east-1
+    ami: ami-00b882ac5193044e4  # Amazon Linux 2, us-east-1
     user: ec2-user
     # ami: ami-61bbf104  # CentOS 7, us-east-1
     # user: centos

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -287,7 +287,7 @@ def cli(cli_context, config, provider, debug):
 @click.option('--ec2-identity-file',
               type=click.Path(exists=True, dir_okay=False),
               help="Path to SSH .pem file for accessing nodes.")
-@click.option('--ec2-instance-type', default='m3.medium', show_default=True)
+@click.option('--ec2-instance-type', default='m5.medium', show_default=True)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
 # We set some of these defaults to empty strings because of boto3's parameter validation.
 # See: https://github.com/boto/boto3/issues/400
@@ -417,7 +417,7 @@ def launch(
         elif spark_git_commit:
             logger.warning(
                 "Warning: Building Spark takes a long time. "
-                "e.g. 15-20 minutes on an m3.xlarge instance on EC2.")
+                "e.g. 15-20 minutes on an m5.xlarge instance on EC2.")
             if spark_git_commit == 'latest':
                 spark_git_commit = get_latest_commit(spark_git_repository)
                 logger.info("Building Spark at latest commit: {c}".format(c=spark_git_commit))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from flintrock.core import StorageDirs
 import pytest
 
 HADOOP_VERSION = '2.8.5'
-SPARK_VERSION = '2.4.3'
+SPARK_VERSION = '2.4.4'
 SPARK_GIT_COMMIT = 'c3e32bf06c35ba2580d46150923abfa795b4446a'  # 2.4.3
 
 
@@ -107,15 +107,15 @@ class ClusterConfig:
 
 
 cluster_configs = [
-    ClusterConfig(restarted=False, instance_type='t2.small'),
-    ClusterConfig(restarted=True, instance_type='t2.small'),
-    ClusterConfig(restarted=False, instance_type='m3.medium'),
-    ClusterConfig(restarted=True, instance_type='m3.medium'),
+    ClusterConfig(restarted=False, instance_type='t3.small'),
+    ClusterConfig(restarted=True, instance_type='t3.small'),
+    ClusterConfig(restarted=False, instance_type='m5.large'),
+    ClusterConfig(restarted=True, instance_type='m5.large'),
     # We don't test all cluster states when building Spark because
     # it takes a very long time.
     ClusterConfig(
         restarted=True,
-        instance_type='m3.xlarge',
+        instance_type='m5.xlarge',
         spark_version='',
         spark_git_commit=SPARK_GIT_COMMIT)]
 
@@ -157,7 +157,7 @@ def stopped_cluster(request):
         '--no-install-hdfs',
         '--no-install-spark',
         '--assume-yes',
-        '--ec2-instance-type', 't2.small'])
+        '--ec2-instance-type', 't3.small'])
     assert p.returncode == 0
 
     p = subprocess.run([

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,7 +16,7 @@ FLINTROCK_ROOT_DIR = (
 @pytest.mark.parametrize(
     'spark_version', [
         (''),
-        ('2.4.3'),
+        ('2.4.4'),
         ('0626b11147133b67b26a04b4819f61a33dd958d3'),
     ])
 def test_templates(dummy_cluster, spark_version):

--- a/tests/test_flintrock.py
+++ b/tests/test_flintrock.py
@@ -158,7 +158,7 @@ def test_get_latest_commit():
 )
 def test_validate_valid_download_source():
     validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz")
-    validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz")
+    validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz")
 
 
 def test_validate_invalid_download_source():


### PR DESCRIPTION
* Spark 2.4.3 -> 2.4.4
* Amazon Linux 2 AMI bump
* EC2 instance type bumps: m3 -> m5, r3 -> r5, t2 -> t3

Tested this with an end-to-end test against AWS.