### PR TITLE
Hadoop 3.x port changes (#306)

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -559,7 +559,7 @@ def get_or_create_flintrock_security_groups(
             src_group=None)
     ]
     for service in services:
-        client_rules += service.create_security_group_rules(flintrock_client_cidr)
+        client_rules += service.get_security_group_rules(flintrock_client_cidr)
 
     # TODO: Don't try adding rules that already exist.
     # TODO: Add rules in one shot.

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -115,9 +115,9 @@ class FlintrockService:
         """
         raise NotImplementedError
 
-    def create_security_group_rules(self, flintrock_client_cidr: str):
+    def get_security_group_rules(self, flintrock_client_cidr: str):
         """
-        Create and return the EC2 SecurityGroupRules required by this service.
+        Return the EC2 SecurityGroupRules required by this service.
         """
         raise NotImplementedError
 
@@ -256,7 +256,7 @@ class HDFS(FlintrockService):
         except Exception as e:
             raise Exception("HDFS health check failed.") from e
 
-    def create_security_group_rules(self, flintrock_client_cidr: str):
+    def get_security_group_rules(self, flintrock_client_cidr: str):
         return [
             SecurityGroupRule(
                 ip_protocol='tcp',
@@ -450,7 +450,7 @@ class Spark(FlintrockService):
             #       dump a large stack trace on the user.
             raise Exception("Spark health check failed.") from e
 
-    def create_security_group_rules(self, flintrock_client_cidr: str):
+    def get_security_group_rules(self, flintrock_client_cidr: str):
         return [
             SecurityGroupRule(
                 ip_protocol='tcp',


### PR DESCRIPTION
This PR makes the following changes:
 * Migrate SecurityGroupRules provisioning to their respective FlintrockService classes (as per the TODO in the source)
 * Use the HDFS version to select the name node ui port number

I tested this PR by creating and launching the following combinations of Spark and Hadoop:
 * Spark 2.4.5, Hadoop 2.8.5
 * Spark 3.0.0rc1. Hadoop 3.2.1

Fixes #306
