### PR TITLE
Allow configuration of EC2 spot request duration

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -31,7 +31,7 @@ providers:
     # ami: ami-61bbf104  # CentOS 7, us-east-1
     # user: centos
     # spot-price: <price>
-    # spot-request-valid-until: 7d  # duration a spot request is valid, supports d/h/m/s (e.g. 4d 3h 2m 1s)
+    # spot-request-duration: 7d  # duration a spot request is valid, supports d/h/m/s (e.g. 4d 3h 2m 1s)
     # vpc-id: <id>
     # subnet-id: <id>
     # placement-group: <name>

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -31,6 +31,7 @@ providers:
     # ami: ami-61bbf104  # CentOS 7, us-east-1
     # user: centos
     # spot-price: <price>
+    # spot-request-valid-until: 7d  # duration a spot request is valid, supports d/h/m/s (e.g. 4d 3h 2m 1s)
     # vpc-id: <id>
     # subnet-id: <id>
     # placement-group: <name>

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -798,7 +798,7 @@ def launch(
         user,
         security_groups,
         spot_price=None,
-        spot_request_valid_until=None,
+        spot_request_duration=None,
         min_root_ebs_size_gb,
         vpc_id,
         subnet_id,
@@ -868,10 +868,10 @@ def launch(
     else:
         user_data = ''
 
-    if spot_request_valid_until is None:
+    if spot_request_duration is None:
         spot_request_valid_until = datetime.utcnow() + timedelta(days=7)
     else:
-        spot_request_valid_until = datetime.utcnow() + duration_to_timedelta(spot_request_valid_until)
+        spot_request_valid_until = datetime.utcnow() + duration_to_timedelta(spot_request_duration)
 
     try:
         cluster_instances = _create_instances(

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -5,7 +5,7 @@ import time
 import urllib.request
 import base64
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # External modules
 import boto3
@@ -25,6 +25,7 @@ from .exceptions import (
 )
 from .ssh import generate_ssh_key_pair
 from .services import SecurityGroupRule
+from .util import duration_to_timedelta
 
 logger = logging.getLogger('flintrock.ec2')
 
@@ -653,6 +654,7 @@ def _create_instances(
         num_instances,
         region,
         spot_price,
+        spot_request_valid_until,
         ami,
         assume_yes,
         key_name,
@@ -681,6 +683,7 @@ def _create_instances(
             spot_requests = client.request_spot_instances(
                 SpotPrice=str(spot_price),
                 InstanceCount=num_instances,
+                ValidUntil=spot_request_valid_until,
                 LaunchSpecification={
                     'ImageId': ami,
                     'KeyName': key_name,
@@ -795,6 +798,7 @@ def launch(
         user,
         security_groups,
         spot_price=None,
+        spot_request_valid_until=None,
         min_root_ebs_size_gb,
         vpc_id,
         subnet_id,
@@ -864,11 +868,17 @@ def launch(
     else:
         user_data = ''
 
+    if spot_request_valid_until is None:
+        spot_request_valid_until = datetime.utcnow() + timedelta(days=7)
+    else:
+        spot_request_valid_until = datetime.utcnow() + duration_to_timedelta(spot_request_valid_until)
+
     try:
         cluster_instances = _create_instances(
             num_instances=num_instances,
             region=region,
             spot_price=spot_price,
+            spot_request_valid_until=spot_request_valid_until,
             ami=ami,
             assume_yes=assume_yes,
             key_name=key_name,

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -5,7 +5,7 @@ import time
 import urllib.request
 import base64
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # External modules
 import boto3
@@ -869,9 +869,9 @@ def launch(
         user_data = ''
 
     if spot_request_duration is None:
-        spot_request_valid_until = datetime.utcnow() + timedelta(days=7)
+        spot_request_valid_until = datetime.now(tz=timezone.utc) + timedelta(days=7)
     else:
-        spot_request_valid_until = datetime.utcnow() + duration_to_timedelta(spot_request_duration)
+        spot_request_valid_until = datetime.now(tz=timezone.utc) + duration_to_timedelta(spot_request_duration)
 
     try:
         cluster_instances = _create_instances(

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -300,7 +300,7 @@ def cli(cli_context, config, provider, debug):
                    "You can specify this option multiple times.")
 @click.option('--ec2-spot-price', type=float)
 @click.option('--ec2-spot-request-duration', default='7d',
-              help="Duration a spot request is valid util (e.g. 3d 2h 1m).")
+              help="Duration a spot request is valid (e.g. 3d 2h 1m).")
 @click.option('--ec2-min-root-ebs-size-gb', type=int, default=30)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
 @click.option('--ec2-subnet-id', default='')

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -299,6 +299,8 @@ def cli(cli_context, config, provider, debug):
               help="Additional security groups names to assign to the instances. "
                    "You can specify this option multiple times.")
 @click.option('--ec2-spot-price', type=float)
+@click.option('--ec2-spot-request-valid-until', default='7d',
+              help="Duration a spot request is valid util (e.g. 3d 2h 1m).")
 @click.option('--ec2-min-root-ebs-size-gb', type=int, default=30)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
 @click.option('--ec2-subnet-id', default='')
@@ -340,6 +342,7 @@ def launch(
         ec2_user,
         ec2_security_groups,
         ec2_spot_price,
+        ec2_spot_request_valid_until,
         ec2_min_root_ebs_size_gb,
         ec2_vpc_id,
         ec2_subnet_id,
@@ -444,6 +447,7 @@ def launch(
             user=ec2_user,
             security_groups=ec2_security_groups,
             spot_price=ec2_spot_price,
+            spot_request_valid_until=ec2_spot_request_valid_until,
             min_root_ebs_size_gb=ec2_min_root_ebs_size_gb,
             vpc_id=ec2_vpc_id,
             subnet_id=ec2_subnet_id,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -299,7 +299,7 @@ def cli(cli_context, config, provider, debug):
               help="Additional security groups names to assign to the instances. "
                    "You can specify this option multiple times.")
 @click.option('--ec2-spot-price', type=float)
-@click.option('--ec2-spot-request-valid-until', default='7d',
+@click.option('--ec2-spot-request-duration', default='7d',
               help="Duration a spot request is valid util (e.g. 3d 2h 1m).")
 @click.option('--ec2-min-root-ebs-size-gb', type=int, default=30)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
@@ -342,7 +342,7 @@ def launch(
         ec2_user,
         ec2_security_groups,
         ec2_spot_price,
-        ec2_spot_request_valid_until,
+        ec2_spot_request_duration,
         ec2_min_root_ebs_size_gb,
         ec2_vpc_id,
         ec2_subnet_id,
@@ -447,7 +447,7 @@ def launch(
             user=ec2_user,
             security_groups=ec2_security_groups,
             spot_price=ec2_spot_price,
-            spot_request_valid_until=ec2_spot_request_valid_until,
+            spot_request_duration=ec2_spot_request_duration,
             min_root_ebs_size_gb=ec2_min_root_ebs_size_gb,
             vpc_id=ec2_vpc_id,
             subnet_id=ec2_subnet_id,

--- a/flintrock/util.py
+++ b/flintrock/util.py
@@ -1,5 +1,7 @@
 import os
 import sys
+from datetime import timedelta
+from decimal import Decimal
 
 FROZEN = getattr(sys, 'frozen', False)
 
@@ -16,3 +18,33 @@ def get_subprocess_env() -> dict:
     if FROZEN:
         env['LD_LIBRARY_PATH'] = env.get('LD_LIBRARY_PATH_ORIG', '')
     return env
+
+
+def duration_to_timedelta(duration_string):
+    """
+    Convert a time duration string (e.g. 3h 4m 10s) into a timedelta
+    """
+
+    duration_string = duration_string.lower()
+
+    total_seconds = Decimal('0')
+
+    prev_num = []
+    for character in duration_string:
+        if character.isalpha():
+            if prev_num:
+                num = Decimal(''.join(prev_num))
+                if character == 'd':
+                    total_seconds += num * 60 * 60 * 24
+                elif character == 'h':
+                    total_seconds += num * 60 * 60
+                elif character == 'm':
+                    total_seconds += num * 60
+                elif character == 's':
+                    total_seconds += num
+                prev_num = []
+
+        elif character.isnumeric() or character == '.':
+            prev_num.append(character)
+
+    return timedelta(seconds=float(total_seconds))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,10 @@
+from datetime import timedelta
+from flintrock.util import duration_to_timedelta
+
+
+def test_duration_to_timedelta():
+    assert duration_to_timedelta('1d') == timedelta(days=1)
+    assert duration_to_timedelta('3d2h1m') == timedelta(days=3, hours=2, minutes=1)
+    assert duration_to_timedelta('4d 2h 1m 5s') == timedelta(days=4, hours=2, minutes=1, seconds=5)
+    assert duration_to_timedelta('36h') == timedelta(hours=36)
+    assert duration_to_timedelta('7d') == timedelta(days=7)


### PR DESCRIPTION
When spinning up ec2 spot instances with flintrock for ad-hoc analysis, there can be cases where capacity is not available for a given instance type. Of course, one can wait until AWS releases instances, however often I find that I just cancel the request and spin up a different type of instance. However, as the default timeout of spot requests is 7 days, it may be that after several minutes/hours/days AWS finally release capacity for a cancelled / unneeded request. This then leads the situation where there are "inconsistent" clusters spun up in AWS, and flintrock has not fully configured them. In this case the instances must be manually terminated from the EC2 console. 

Additionally, there can be the scenario where a request is cancelled, a new request for a different instance is then created (with the same name), and both requests end up being fulfilled, which the causes issues with describe/destroy. In this PR, I have added support for using a human readable timedelta (e.g. `'7d'`, `'5m'`) in configuration/cli such that the spot request timeout can be controlled by the user (and it retains the default of 7 days). This would alleviate the problems described above, where I could simply reduce the spot request duration to be much shorter than 7 days.

This PR makes the following changes:
* Adds support for the `ValidUntil` parameter when creating ec2 spot requests
* Retains the default option where requests are valid for 7 days

I tested this PR by running pytest locally and adding new tests for the util function. However, I have not run any of the acceptance tests.