### PR TITLE
Add support for configurable JDKs

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -53,5 +53,6 @@ launch:
   num-slaves: 1
   # install-hdfs: True
   # install-spark: False
+  # java-version: 8
 
 debug: false

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -575,7 +575,7 @@ def ensure_java(client: paramiko.client.SSHClient, java_version: int):
             # Install Java first to protect packages that depend on Java from being removed.
             sudo yum install -q -y {jp}
 
-            # Remove any older versions of Java to force the default Java to 1.8.
+            # Remove any older versions of Java to force the default Java to the requested version.
             # We don't use /etc/alternatives because it does not seem to update links in /usr/lib/jvm correctly,
             # and we don't just rely on JAVA_HOME because some programs use java directly in the PATH.
             sudo yum remove -y java-1.6.0-openjdk java-1.7.0-openjdk

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -268,7 +268,7 @@ class FlintrockCluster:
     def add_slaves_check(self):
         pass
 
-    def add_slaves(self, *, user: str, identity_file: str, new_hosts: list):
+    def add_slaves(self, *, user: str, identity_file: str, java_version: int, new_hosts: list):
         """
         Add new slaves to the cluster.
 
@@ -285,6 +285,7 @@ class FlintrockCluster:
             services=self.services,
             user=user,
             identity_file=identity_file,
+            java_version=java_version,
             cluster=self,
             new_hosts=new_hosts)
         run_against_hosts(partial_func=partial_func, hosts=hosts)
@@ -544,7 +545,7 @@ def ensure_java(client: paramiko.client.SSHClient, java_version: int):
             client=client,
             command="""
                 set -e
-                
+
                 # Install Java first to protect packages that depend on Java from being removed.
                 sudo yum install -q -y {jp}
 
@@ -553,7 +554,6 @@ def ensure_java(client: paramiko.client.SSHClient, java_version: int):
                 # and we don't just rely on JAVA_HOME because some programs use java directly in the PATH.
                 sudo yum remove -y java-1.6.0-openjdk java-1.7.0-openjdk
 
-                # sudo alternatives --set java {jp}.x86_64
                 sudo sh -c "echo export JAVA_HOME=/usr/lib/jvm/{jp} >> /etc/environment"
                 source /etc/environment
             """.format(jp=java_package))
@@ -571,7 +571,7 @@ def install_adoptopenjdk_repo(client):
         client=client,
         command="""
             # Use sudo to install the repo file
-            sudo mv /tmp/adoptopenjdk.repo /etc/yum.repos.d/        
+            sudo mv /tmp/adoptopenjdk.repo /etc/yum.repos.d/
         """
     )
 
@@ -767,6 +767,7 @@ def add_slaves_node(
         user: str,
         host: str,
         identity_file: str,
+        java_version: int,
         services: list,
         cluster: FlintrockCluster,
         new_hosts: list):
@@ -790,6 +791,7 @@ def add_slaves_node(
             setup_node(
                 ssh_client=client,
                 services=services,
+                java_version=java_version,
                 cluster=cluster)
 
         for service in services:

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -787,6 +787,7 @@ def launch(
         *,
         cluster_name,
         num_slaves,
+        jdk,
         services,
         assume_yes,
         key_name,
@@ -933,6 +934,7 @@ def launch(
 
         provision_cluster(
             cluster=cluster,
+            jdk=jdk,
             services=services,
             user=user,
             identity_file=identity_file)

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -249,7 +249,9 @@ class EC2Cluster(FlintrockCluster):
             user: str,
             identity_file: str,
             num_slaves: int,
+            java_version: int,
             spot_price: float,
+            spot_request_valid_until: str,
             min_root_ebs_size_gb: int,
             tags: list,
             assume_yes: bool):
@@ -294,6 +296,7 @@ class EC2Cluster(FlintrockCluster):
                 num_instances=num_slaves,
                 region=self.region,
                 spot_price=spot_price,
+                spot_request_valid_until=spot_request_valid_until,
                 ami=self.master_instance.image_id,
                 assume_yes=assume_yes,
                 key_name=self.master_instance.key_name,
@@ -331,6 +334,7 @@ class EC2Cluster(FlintrockCluster):
             super().add_slaves(
                 user=user,
                 identity_file=identity_file,
+                java_version=java_version,
                 new_hosts=new_slaves)
         except (Exception, KeyboardInterrupt) as e:
             if isinstance(e, InterruptedEC2Operation):

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -787,7 +787,7 @@ def launch(
         *,
         cluster_name,
         num_slaves,
-        jdk,
+        java_version,
         services,
         assume_yes,
         key_name,
@@ -934,7 +934,7 @@ def launch(
 
         provision_cluster(
             cluster=cluster,
-            jdk=jdk,
+            java_version=java_version,
             services=services,
             user=user,
             identity_file=identity_file)

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -253,6 +253,7 @@ def cli(cli_context, config, provider, debug):
 @cli.command()
 @click.argument('cluster-name')
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
+@click.option('--jdk', type=click.IntRange(min=8), default=8)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
 @click.option('--hdfs-version', default='2.8.5')
 @click.option('--hdfs-download-source',
@@ -323,6 +324,7 @@ def launch(
         cli_context,
         cluster_name,
         num_slaves,
+        jdk,
         install_hdfs,
         hdfs_version,
         hdfs_download_source,
@@ -436,6 +438,7 @@ def launch(
         cluster = ec2.launch(
             cluster_name=cluster_name,
             num_slaves=num_slaves,
+            jdk=jdk,
             services=services,
             assume_yes=assume_yes,
             key_name=ec2_key_name,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -253,7 +253,7 @@ def cli(cli_context, config, provider, debug):
 @cli.command()
 @click.argument('cluster-name')
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
-@click.option('--jdk', type=click.IntRange(min=8), default=8)
+@click.option('--java-version', type=click.IntRange(min=8), default=8)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
 @click.option('--hdfs-version', default='2.8.5')
 @click.option('--hdfs-download-source',
@@ -324,7 +324,7 @@ def launch(
         cli_context,
         cluster_name,
         num_slaves,
-        jdk,
+        java_version,
         install_hdfs,
         hdfs_version,
         hdfs_download_source,
@@ -438,7 +438,7 @@ def launch(
         cluster = ec2.launch(
             cluster_name=cluster_name,
             num_slaves=num_slaves,
-            jdk=jdk,
+            java_version=java_version,
             services=services,
             assume_yes=assume_yes,
             key_name=ec2_key_name,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -717,6 +717,7 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 
 @cli.command(name='add-slaves')
 @click.argument('cluster-name')
+@click.option('--java-version', type=click.IntRange(min=8), default=8)
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
@@ -725,6 +726,8 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
               help="Path to SSH .pem file for accessing nodes.")
 @click.option('--ec2-user')
 @click.option('--ec2-spot-price', type=float)
+@click.option('--ec2-spot-request-duration', default='7d',
+              help="Duration a spot request is valid (e.g. 3d 2h 1m).")
 @click.option('--ec2-min-root-ebs-size-gb', type=int, default=30)
 @click.option('--assume-yes/--no-assume-yes', default=False)
 @click.option('--ec2-tag', 'ec2_tags',
@@ -736,12 +739,14 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 def add_slaves(
         cli_context,
         cluster_name,
+        java_version,
         num_slaves,
         ec2_region,
         ec2_vpc_id,
         ec2_identity_file,
         ec2_user,
         ec2_spot_price,
+        ec2_spot_request_duration,
         ec2_min_root_ebs_size_gb,
         ec2_tags,
         assume_yes):
@@ -772,6 +777,7 @@ def add_slaves(
         provider_options = {
             'min_root_ebs_size_gb': ec2_min_root_ebs_size_gb,
             'spot_price': ec2_spot_price,
+            'spot_request_valid_until': ec2_spot_request_duration,
             'tags': ec2_tags
         }
     else:
@@ -793,6 +799,7 @@ def add_slaves(
         cluster.add_slaves(
             user=user,
             identity_file=identity_file,
+            java_version=java_version,
             num_slaves=num_slaves,
             assume_yes=assume_yes,
             **provider_options)

--- a/flintrock/scripts/adoptopenjdk.repo
+++ b/flintrock/scripts/adoptopenjdk.repo
@@ -1,0 +1,6 @@
+[AdoptOpenJDK]
+name=AdoptOpenJDK
+baseurl=http://adoptopenjdk.jfrog.io/adoptopenjdk/rpm/centos/8/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public


### PR DESCRIPTION
This PR makes the following changes:
* Adds support for user configurable JDKs in order to enable JDK 11 or newer to be installed
* 

I tested this PR by...

1. Creating and running Java 8 based clusters
2. Creating and running Java 11 based clusters

