### PR TITLE
Automatically select Hadoop build to use for Spark

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,11 @@
 
 * [#296]: Added support for launching clusters into private VPCs.
 * [#324]: Flintrock now supports S3 URLs as a download source for Hadoop or Spark. This makes it easy to host your own copies of the Hadoop and Spark release builds in a private bucket.
+* [#323]: Flintrock now automatically selects the correct build of Spark to use, based on the version of Hadoop/HDFS that you specify.
 
 [#296]: https://github.com/nchammas/flintrock/pull/296
 [#324]: https://github.com/nchammas/flintrock/pull/324
+[#323]: https://github.com/nchammas/flintrock/pull/323
 
 ### Changed
 

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -7,19 +7,19 @@ services:
     #   - can be http, https, or s3 URL
     #   - must contain a {v} template corresponding to the version
     #   - Spark must be pre-built
-    #   - must be a tar.gz file
-    # download-source: "https://www.example.com/files/spark/{v}/spark-{v}.tgz"
-    # download-source: "s3://some-bucket/spark/{v}/spark-{v}.tgz"
+    #   - files must be named according to release pattern on dist.apache.org
+    # download-source: "https://www.example.com/files/spark/{v}/"
+    # download-source: "s3://some-bucket/spark/{v}/"
     # executor-instances: 1
   hdfs:
     version: 2.8.5
     # optional; defaults to download from a dynamically selected Apache mirror
     #   - can be http, https, or s3 URL
     #   - must contain a {v} template corresponding to the version
-    #   - must be a .tar.gz file
-    # download-source: "https://www.example.com/files/hadoop/{v}/hadoop-{v}.tar.gz"
-    # download-source: "http://www-us.apache.org/dist/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz"
-    # download-source: "s3://some-bucket/hadoop/{v}/hadoop-{v}.tar.gz"
+    #   - files must be named according to release pattern on dist.apache.org
+    # download-source: "https://www.example.com/files/hadoop/{v}/"
+    # download-source: "http://www-us.apache.org/dist/hadoop/common/hadoop-{v}/"
+    # download-source: "s3://some-bucket/hadoop/{v}/"
 
 provider: ec2
 

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -7,7 +7,7 @@ services:
     #   - can be http, https, or s3 URL
     #   - must contain a {v} template corresponding to the version
     #   - Spark must be pre-built
-    #   - files must be named according to release pattern on dist.apache.org
+    #   - files must be named according to the release pattern shown here: https://dist.apache.org/repos/dist/release/spark/
     # download-source: "https://www.example.com/files/spark/{v}/"
     # download-source: "s3://some-bucket/spark/{v}/"
     # executor-instances: 1
@@ -16,7 +16,7 @@ services:
     # optional; defaults to download from a dynamically selected Apache mirror
     #   - can be http, https, or s3 URL
     #   - must contain a {v} template corresponding to the version
-    #   - files must be named according to release pattern on dist.apache.org
+    #   - files must be named according to the release pattern shown here: https://dist.apache.org/repos/dist/release/hadoop/common/
     # download-source: "https://www.example.com/files/hadoop/{v}/"
     # download-source: "http://www-us.apache.org/dist/hadoop/common/hadoop-{v}/"
     # download-source: "s3://some-bucket/hadoop/{v}/"

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -285,7 +285,8 @@ def cli(cli_context, config, provider, debug):
                   "URL to download Hadoop from. If an S3 URL, Flintrock will use the "
                   "AWS CLI from the cluster nodes to download it. "
                   "Flintrock will append the appropriate file name to the end "
-                  "of the URL based on the Apache release file names on dist.apache.org."
+                  "of the URL based on the Apache release file names here: "
+                  "https://dist.apache.org/repos/dist/release/hadoop/common/"
               ),
               default='https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-{v}/',
               show_default=True,
@@ -305,7 +306,8 @@ def cli(cli_context, config, provider, debug):
                   "AWS CLI from the cluster nodes to download it. "
                   "Flintrock will append the appropriate file "
                   "name to the end of the URL based on the selected Hadoop version and "
-                  "Apache release file names on dist.apache.org."
+                  "Apache release file names here: "
+                  "https://dist.apache.org/repos/dist/release/spark/"
               ),
               default='https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-{v}/',
               show_default=True,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -263,7 +263,7 @@ def cli(cli_context, config, provider, debug):
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
 @click.option('--java-version', type=click.IntRange(min=8), default=8)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
-@click.option('--hdfs-version', default='3.3.0')
+@click.option('--hdfs-version', default='2.8.5')
 @click.option('--hdfs-download-source',
               help=
                 "URL to download Hadoop from. Flintrock will append the appropriate file "

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -269,7 +269,7 @@ def cli(cli_context, config, provider, debug):
                   "URL to download Hadoop from. If an S3 URL, Flintrock will use the "
                   "AWS CLI from the cluster nodes to download it. "
                   "Flintrock will append the appropriate file name to the end "
-                  "of the URL based on the Apache release file names."
+                  "of the URL based on the Apache release file names on dist.apache.org."
               ),
               default='https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-{v}/',
               show_default=True,
@@ -289,7 +289,7 @@ def cli(cli_context, config, provider, debug):
                   "AWS CLI from the cluster nodes to download it. "
                   "Flintrock will append the appropriate file "
                   "name to the end of the URL based on the selected Hadoop version and "
-                  "Apache release file names."
+                  "Apache release file names on dist.apache.org."
               ),
               default='https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-{v}/',
               show_default=True,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -286,7 +286,7 @@ def cli(cli_context, config, provider, debug):
 @click.option('--spark-download-source',
               help=(
                   "URL to download Spark from. If an S3 URL, Flintrock will use the "
-                  "AWS CLI from the cluster nodes to download it."
+                  "AWS CLI from the cluster nodes to download it. "
                   "Flintrock will append the appropriate file "
                   "name to the end of the URL based on the selected Hadoop version and "
                   "Apache release file names."

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -176,19 +176,35 @@ def configure_log(debug: bool):
 
 def build_hdfs_download_url(ctx, param, value):
     hdfs_version = ctx.params['hdfs_version']
-    hdfs_download_url = (value.rstrip('/') + '/hadoop-{v}.tar.gz').format(v=hdfs_version)
-    return hdfs_download_url
+    if value.endswith('.gz') or value.endswith('.tgz'):
+        logger.debug(
+            "Hadoop download source appears to point to a file, not a directory. "
+            "Flintrock will not try to determine the correct file to download based on "
+            "the Hadoop version."
+        )
+        hdfs_download_url = value
+    else:
+        hdfs_download_url = (value.rstrip('/') + '/hadoop-{v}.tar.gz')
+    return hdfs_download_url.format(v=hdfs_version)
 
 
 def build_spark_download_url(ctx, param, value):
     spark_version = ctx.params['spark_version']
     hadoop_version = ctx.params['hdfs_version']
     hadoop_build_version = spark_hadoop_build_version(hadoop_version)
-    spark_download_url = (value.rstrip('/') + '/spark-{v}-bin-{hv}.tgz').format(
+    if value.endswith('.gz') or value.endswith('.tgz'):
+        logger.debug(
+            "Spark download source appears to point to a file, not a directory. "
+            "Flintrock will not try to determine the correct file to download based on "
+            "the Spark and Hadoop versions."
+        )
+        spark_download_url = value
+    else:
+        spark_download_url = (value.rstrip('/') + '/spark-{v}-bin-{hv}.tgz')
+    return spark_download_url.format(
         v=spark_version,
         hv=hadoop_build_version,
     )
-    return spark_download_url
 
 
 def validate_download_source(url):

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -177,7 +177,7 @@ def configure_log(debug: bool):
 def build_hdfs_download_url(ctx, param, value):
     hdfs_version = ctx.params['hdfs_version']
     if value.endswith('.gz') or value.endswith('.tgz'):
-        logger.debug(
+        logger.warning(
             "Hadoop download source appears to point to a file, not a directory. "
             "Flintrock will not try to determine the correct file to download based on "
             "the Hadoop version."
@@ -193,7 +193,7 @@ def build_spark_download_url(ctx, param, value):
     hadoop_version = ctx.params['hdfs_version']
     hadoop_build_version = spark_hadoop_build_version(hadoop_version)
     if value.endswith('.gz') or value.endswith('.tgz'):
-        logger.debug(
+        logger.warning(
             "Spark download source appears to point to a file, not a directory. "
             "Flintrock will not try to determine the correct file to download based on "
             "the Spark and Hadoop versions."

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -17,6 +17,7 @@ from .core import (
     get_formatted_template,
 )
 from .ssh import ssh_check_output
+from .util import spark_hadoop_build_version
 
 FROZEN = getattr(sys, 'frozen', False)
 
@@ -401,9 +402,7 @@ class Spark(FlintrockService):
                 """.format(
                     repo=shlex.quote(self.git_repository),
                     commit=shlex.quote(self.git_commit),
-                    # Hardcoding this here until we figure out a better way to handle
-                    # the supported build profiles.
-                    hadoop_short_version='2.7',
+                    hadoop_short_version=spark_hadoop_build_version(self.hadoop_version),
                 ))
         ssh_check_output(
             client=ssh_client,

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -130,16 +130,27 @@ class HDFS(FlintrockService):
         self.manifest = {'version': version, 'download_source': download_source}
 
     def install(
-            self,
-            ssh_client: paramiko.client.SSHClient,
-            cluster: FlintrockCluster):
-        logger.info("[{h}] Installing HDFS...".format(
-            h=ssh_client.get_transport().getpeername()[0]))
+        self,
+        ssh_client: paramiko.client.SSHClient,
+        cluster: FlintrockCluster,
+    ):
+        logger.info(
+            "[{h}] Installing HDFS..."
+            .format(h=ssh_client.get_transport().getpeername()[0])
+        )
 
         with ssh_client.open_sftp() as sftp:
             sftp.put(
                 localpath=os.path.join(SCRIPTS_DIR, 'download-package.py'),
                 remotepath='/tmp/download-package.py')
+
+        logger.debug(
+            "[{h}] Downloading Hadoop from: {s}"
+            .format(
+                h=ssh_client.get_transport().getpeername()[0],
+                s=self.download_source,
+            )
+        )
 
         ssh_check_output(
             client=ssh_client,
@@ -303,17 +314,28 @@ class Spark(FlintrockService):
             'git_repository': git_repository}
 
     def install(
-            self,
-            ssh_client: paramiko.client.SSHClient,
-            cluster: FlintrockCluster):
-        logger.info("[{h}] Installing Spark...".format(
-            h=ssh_client.get_transport().getpeername()[0]))
+        self,
+        ssh_client: paramiko.client.SSHClient,
+        cluster: FlintrockCluster,
+    ):
+        logger.info(
+            "[{h}] Installing Spark..."
+            .format(h=ssh_client.get_transport().getpeername()[0])
+        )
 
         if self.version:
             with ssh_client.open_sftp() as sftp:
                 sftp.put(
                     localpath=os.path.join(SCRIPTS_DIR, 'download-package.py'),
                     remotepath='/tmp/download-package.py')
+
+            logger.debug(
+                "[{h}] Downloading Spark from: {s}"
+                .format(
+                    h=ssh_client.get_transport().getpeername()[0],
+                    s=self.download_source,
+                )
+            )
 
             ssh_check_output(
                 client=ssh_client,
@@ -323,7 +345,6 @@ class Spark(FlintrockService):
                     # version=self.version,
                     download_source=self.download_source.format(v=self.version),
                 ))
-
         else:
             ssh_check_output(
                 client=ssh_client,
@@ -332,6 +353,16 @@ class Spark(FlintrockService):
                     sudo yum install -y git
                     sudo yum install -y java-devel
                     """)
+
+            logger.debug(
+                "[{h}] Cloning Spark at {c} from: {s}"
+                .format(
+                    h=ssh_client.get_transport().getpeername()[0],
+                    c=self.git_commit,
+                    s=self.git_repository,
+                )
+            )
+
             ssh_check_output(
                 client=ssh_client,
                 command="""

--- a/flintrock/util.py
+++ b/flintrock/util.py
@@ -65,10 +65,7 @@ def spark_hadoop_build_version(hadoop_version: str) -> str:
     """
     Given a Hadoop version, determine the Hadoop build of Spark to use.
     """
-    try:
-        hadoop_version = tuple(map(int, hadoop_version.split('.')))
-    except ValueError as e:
-        return 'without-hadoop'
+    hadoop_version = tuple(map(int, hadoop_version.split('.')))
     if hadoop_version < (2, 7):
         return 'hadoop2.6'
     elif (2, 7) <= hadoop_version < (3, 0):

--- a/flintrock/util.py
+++ b/flintrock/util.py
@@ -65,7 +65,6 @@ def spark_hadoop_build_version(hadoop_version: str) -> str:
     """
     Given a Hadoop version, determine the Hadoop build of Spark to use.
     """
-    print(hadoop_version)
     try:
         hadoop_version = tuple(map(int, hadoop_version.split('.')))
     except ValueError as e:

--- a/flintrock/util.py
+++ b/flintrock/util.py
@@ -48,3 +48,20 @@ def duration_to_timedelta(duration_string):
             prev_num.append(character)
 
     return timedelta(seconds=float(total_seconds))
+
+
+def spark_hadoop_build_version(hadoop_version: str) -> str:
+    """
+    Given a Hadoop version, determine the Hadoop build of Spark to use.
+    """
+    print(hadoop_version)
+    try:
+        hadoop_version = tuple(map(int, hadoop_version.split('.')))
+    except ValueError as e:
+        return 'without-hadoop'
+    if hadoop_version < (2, 7):
+        return 'hadoop2.6'
+    elif (2, 7) <= hadoop_version < (3, 0):
+        return 'hadoop2.7'
+    elif (3, 0) <= hadoop_version:
+        return 'hadoop3.2'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,9 @@
 from datetime import datetime, timedelta, timezone
-from flintrock.util import duration_to_timedelta, duration_to_expiration
+from flintrock.util import (
+    duration_to_timedelta,
+    duration_to_expiration,
+    spark_hadoop_build_version,
+)
 from freezegun import freeze_time
 
 
@@ -14,3 +18,7 @@ def test_duration_to_timedelta():
 @freeze_time("2012-01-14")
 def test_duration_to_expiration():
     assert duration_to_expiration('5m') == datetime.now(tz=timezone.utc) + timedelta(minutes=5)
+
+
+def test_spark_hadoop_build_version():
+    assert spark_hadoop_build_version('3.1.3') == 'hadoop3.2'


### PR DESCRIPTION
Spark releases are built against multiple versions of Hadoop. Keeping track of what build to use can be irritating. Flintrock will now use the selected Hadoop version to automatically select the appropriate build of Spark to use.

This simplifies things for the user but changes the format of the two `download-source` options. Flintrock should somehow smooth the transition of formats for users.

TODO:
- [x] Add changelog.
- [x] Bump major version.
- [x] Add test for new Hadoop build version utility.
- [x] Explain how file name is generated, with reference to dist.apache.org.
- [x] Detect old download source format and raise deprecation warning.
- [ ] ~Print helper message on appropriate version of hadoop-aws to use. (?)~
- [x] Show generated download URLs in debug output.

Related: #322