### PR TITLE
Allow Spark/Hadoop download source to be an S3 URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@
 
 [Unreleased]: https://github.com/nchammas/flintrock/compare/v1.0.0...master
 
+### Added
+
+* [#324]: Flintrock now supports S3 URLs as a download source for Hadoop or Spark. This makes it easy to host your own copies of the Hadoop and Spark release builds in a private bucket.
+
+[#324]: https://github.com/nchammas/flintrock/pull/324
+
 ### Changed
 
 * [#311]: Changed how Flintrock manages its own security groups to reduce the likelihood of hitting any limits on the number of rules per security group.

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -3,19 +3,23 @@ services:
     version: 2.4.5
     # git-commit: latest  # if not 'latest', provide a full commit SHA; e.g. d6dc12ef0146ae409834c78737c116050961f350
     # git-repository:  # optional; defaults to https://github.com/apache/spark
-    # optional; defaults to download from from the official Spark S3 bucket
+    # optional; defaults to download from a dynamically selected Apache mirror
+    #   - can be http, https, or s3 URL
     #   - must contain a {v} template corresponding to the version
     #   - Spark must be pre-built
     #   - must be a tar.gz file
-    # download-source: "https://www.example.com/files/spark/{v}/spark-{v}.tar.gz"
+    # download-source: "https://www.example.com/files/spark/{v}/spark-{v}.tgz"
+    # download-source: "s3://some-bucket/spark/{v}/spark-{v}.tgz"
     # executor-instances: 1
   hdfs:
     version: 2.8.5
     # optional; defaults to download from a dynamically selected Apache mirror
+    #   - can be http, https, or s3 URL
     #   - must contain a {v} template corresponding to the version
     #   - must be a .tar.gz file
     # download-source: "https://www.example.com/files/hadoop/{v}/hadoop-{v}.tar.gz"
     # download-source: "http://www-us.apache.org/dist/hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz"
+    # download-source: "s3://some-bucket/hadoop/{v}/hadoop-{v}.tar.gz"
 
 provider: ec2
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -257,7 +257,10 @@ def cli(cli_context, config, provider, debug):
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
 @click.option('--hdfs-version', default='2.8.5')
 @click.option('--hdfs-download-source',
-              help="URL to download Hadoop from.",
+              help=(
+                  "URL to download Hadoop from. If an S3 URL, Flintrock will use the "
+                  "AWS CLI from the cluster nodes to download it."
+              ),
               default='https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-{v}/hadoop-{v}.tar.gz',
               show_default=True,
               callback=build_hdfs_download_url)
@@ -271,7 +274,10 @@ def cli(cli_context, config, provider, debug):
               # default=,
               help="Spark release version to install.")
 @click.option('--spark-download-source',
-              help="URL to download a release of Spark from.",
+              help=(
+                  "URL to download Spark from. If an S3 URL, Flintrock will use the "
+                  "AWS CLI from the cluster nodes to download it."
+              ),
               default='https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-{v}/spark-{v}-bin-hadoop2.7.tgz',
               show_default=True,
               callback=build_spark_download_url)

--- a/flintrock/scripts/download-package.py
+++ b/flintrock/scripts/download-package.py
@@ -34,7 +34,10 @@ if __name__ == '__main__':
     tries = 0
     while True:
         try:
-            subprocess.check_call(['curl', '--location', '--output', download_path, url])
+            if url.startswith('s3://'):
+                subprocess.check_call(['aws', 's3', 'cp', url, download_path])
+            else:
+                subprocess.check_call(['curl', '--location', '--output', download_path, url])
             subprocess.check_call(['gzip', '--test', download_path])
             subprocess.check_call(['tar', 'xzf', download_path, '-C', destination_dir, '--strip-components=1'])
             subprocess.check_call(['rm', download_path])


### PR DESCRIPTION
Downloading from the Apache mirrors is slow. Most heavy users of Flintrock will likely want to host Spark and Hadoop download artifacts on S3 and have launched clusters download from there.

This change allows Flintrock to do that.

TODO:
- [x] Update docstrings, config template, and maybe also main README.
- [x] Add changelog.