### PR TITLE
Drop Python 3.5 support + bump some test & transitive dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ matrix:
     - python: "3.7"
       dist: "xenial"
       sudo: true
+    - python: "3.8"
+      dist: "xenial"
+      sudo: true
+    - python: "3.9"
+      dist: "xenial"
+      sudo: true
 install:
   - "pip install -r requirements/maintainer.pip"
   # Fix for PyInstaller: https://stackoverflow.com/q/61574984/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 python:
-  - "3.6"
 # Work-around for Python 3.7 on Travis CI pulled from here:
 # https://github.com/travis-ci/travis-ci/issues/9815#issue-336465122
 matrix:
   include:
+    - python: "3.6"
+      dist: "xenial"
+      sudo: true
     - python: "3.7"
       dist: "xenial"
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
 # Work-around for Python 3.7 on Travis CI pulled from here:
 # https://github.com/travis-ci/travis-ci/issues/9815#issue-336465122

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,10 @@
 ### Changed
 
 * [#311]: Changed how Flintrock manages its own security groups to reduce the likelihood of hitting any limits on the number of rules per security group.
+* [#329]: Dropped support for Python 3.5 and added automated testing for Python 3.8 and 3.9.
 
 [#311]: https://github.com/nchammas/flintrock/pull/311
+[#329]: https://github.com/nchammas/flintrock/pull/329
 
 ## [1.0.0] - 2020-01-11
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ There are a few things you should do before diving in to write a new feature or 
 If you are changing anything about Flintrock's dependencies, be sure to update the compiled requirements using [pip-tools]:
 
 ```
-pip install -U pip-tools
+pip install -U "pip-tools<6"
 pip-compile -U requirements/user.in -o requirements/user.pip
 pip-compile -U requirements/developer.in -o requirements/developer.pip
 pip-compile -U requirements/maintainer.in -o requirements/maintainer.pip

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Before using Flintrock, take a quick look at the
 notice and [license](https://github.com/nchammas/flintrock/blob/master/LICENSE)
 and make sure you're OK with their terms.
 
-**Flintrock requires Python 3.5 or newer**, unless you are using one
+**Flintrock requires Python 3.6 or newer**, unless you are using one
 of our **standalone packages**. Flintrock has been thoroughly tested
 only on OS X, but it should run on all POSIX systems.
 A motivated contributor should be able to add

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -1073,9 +1073,9 @@ def config_to_click(config: dict) -> dict:
 
     click_map = {
         'launch': dict(
-            list(config['launch'].items()) +
-            list(ec2_configs.items()) +
-            list(service_configs.items())),
+            list(config['launch'].items())
+            + list(ec2_configs.items())
+            + list(service_configs.items())),
         'describe': ec2_configs,
         'destroy': ec2_configs,
         'login': ec2_configs,

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -154,7 +154,7 @@ class HDFS(FlintrockService):
 
                 echo "export HADOOP_LIBEXEC_DIR='$(pwd)/hadoop/libexec'" >> .bashrc
             """.format(
-                version=self.version,
+                # version=self.version,
                 download_source=self.download_source.format(v=self.version),
             ))
 
@@ -317,7 +317,7 @@ class Spark(FlintrockService):
                 command="""
                     python /tmp/download-package.py "{download_source}" "spark"
                 """.format(
-                    version=self.version,
+                    # version=self.version,
                     download_source=self.download_source.format(v=self.version),
                 ))
 

--- a/requirements/developer.in
+++ b/requirements/developer.in
@@ -1,6 +1,6 @@
 -r user.pip
 pytest >= 3.5.0
 pytest-cov >= 2.5.1
-flake8 == 3.5.0
+flake8 == 3.8.4
 freezegun == 1.1.0
 # PyYAML  # requirement already covered by setup.py

--- a/requirements/developer.pip
+++ b/requirements/developer.pip
@@ -6,9 +6,9 @@
 #
 -e file:.#egg=Flintrock
     # via -r requirements/user.pip
-attrs==19.3.0
+attrs==20.3.0
     # via pytest
-bcrypt==3.1.7
+bcrypt==3.2.0
     # via
     #   -r requirements/user.pip
     #   paramiko
@@ -22,7 +22,7 @@ botocore==1.13.45
     #   boto3
     #   flintrock
     #   s3transfer
-cffi==1.13.2
+cffi==1.14.4
     # via
     #   -r requirements/user.pip
     #   bcrypt
@@ -32,9 +32,9 @@ click==7.0
     # via
     #   -r requirements/user.pip
     #   flintrock
-coverage==5.0.1
+coverage==5.4
     # via pytest-cov
-cryptography==2.8
+cryptography==3.4.2
     # via
     #   -r requirements/user.pip
     #   flintrock
@@ -47,20 +47,20 @@ flake8==3.5.0
     # via -r requirements/developer.in
 freezegun==1.1.0
     # via -r requirements/developer.in
-importlib-metadata==1.3.0
+importlib-metadata==3.4.0
     # via
     #   pluggy
     #   pytest
-jmespath==0.9.4
+iniconfig==1.1.1
+    # via pytest
+jmespath==0.10.0
     # via
     #   -r requirements/user.pip
     #   boto3
     #   botocore
 mccabe==0.6.1
     # via flake8
-more-itertools==8.0.2
-    # via pytest
-packaging==19.2
+packaging==20.9
     # via pytest
 paramiko==2.7.1
     # via
@@ -68,25 +68,25 @@ paramiko==2.7.1
     #   flintrock
 pluggy==0.13.1
     # via pytest
-py==1.8.0
+py==1.10.0
     # via pytest
 pycodestyle==2.3.1
     # via flake8
-pycparser==2.19
+pycparser==2.20
     # via
     #   -r requirements/user.pip
     #   cffi
 pyflakes==1.6.0
     # via flake8
-pynacl==1.3.0
+pynacl==1.4.0
     # via
     #   -r requirements/user.pip
     #   paramiko
-pyparsing==2.4.6
+pyparsing==2.4.7
     # via packaging
-pytest-cov==2.8.1
+pytest-cov==2.11.1
     # via -r requirements/developer.in
-pytest==5.3.2
+pytest==6.2.2
     # via
     #   -r requirements/developer.in
     #   pytest-cov
@@ -103,19 +103,19 @@ s3transfer==0.2.1
     # via
     #   -r requirements/user.pip
     #   boto3
-six==1.13.0
+six==1.15.0
     # via
     #   -r requirements/user.pip
     #   bcrypt
-    #   cryptography
-    #   packaging
     #   pynacl
     #   python-dateutil
-urllib3==1.25.7
+toml==0.10.2
+    # via pytest
+typing-extensions==3.7.4.3
+    # via importlib-metadata
+urllib3==1.25.11
     # via
     #   -r requirements/user.pip
     #   botocore
-wcwidth==0.1.7
-    # via pytest
-zipp==0.6.0
+zipp==3.4.0
     # via importlib-metadata

--- a/requirements/developer.pip
+++ b/requirements/developer.pip
@@ -43,12 +43,13 @@ docutils==0.15.2
     # via
     #   -r requirements/user.pip
     #   botocore
-flake8==3.5.0
+flake8==3.8.4
     # via -r requirements/developer.in
 freezegun==1.1.0
     # via -r requirements/developer.in
 importlib-metadata==3.4.0
     # via
+    #   flake8
     #   pluggy
     #   pytest
 iniconfig==1.1.1
@@ -70,13 +71,13 @@ pluggy==0.13.1
     # via pytest
 py==1.10.0
     # via pytest
-pycodestyle==2.3.1
+pycodestyle==2.6.0
     # via flake8
 pycparser==2.20
     # via
     #   -r requirements/user.pip
     #   cffi
-pyflakes==1.6.0
+pyflakes==2.2.0
     # via flake8
 pynacl==1.4.0
     # via

--- a/requirements/maintainer.in
+++ b/requirements/maintainer.in
@@ -2,4 +2,3 @@
 wheel >= 0.31.0
 twine == 1.15.0
 PyInstaller == 3.5
-keyring < 21.0.0  # to maintain compatibility for Python 3.5

--- a/requirements/maintainer.in
+++ b/requirements/maintainer.in
@@ -1,4 +1,4 @@
 -r developer.pip
 wheel >= 0.31.0
 twine == 1.15.0
-PyInstaller == 3.5
+PyInstaller == 4.2

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -69,6 +69,7 @@ importlib-metadata==3.4.0
     #   -r requirements/developer.pip
     #   flake8
     #   pluggy
+    #   pyinstaller
     #   pytest
 iniconfig==1.1.1
     # via
@@ -118,7 +119,9 @@ pyflakes==2.2.0
     #   flake8
 pygments==2.7.4
     # via readme-renderer
-pyinstaller==3.5
+pyinstaller-hooks-contrib==2020.11
+    # via pyinstaller
+pyinstaller==4.2
     # via -r requirements/maintainer.in
 pynacl==1.4.0
     # via

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -10,11 +10,11 @@ altgraph==0.17
     # via
     #   macholib
     #   pyinstaller
-attrs==19.3.0
+attrs==20.3.0
     # via
     #   -r requirements/developer.pip
     #   pytest
-bcrypt==3.1.7
+bcrypt==3.2.0
     # via
     #   -r requirements/developer.pip
     #   paramiko
@@ -32,7 +32,7 @@ botocore==1.13.45
     #   s3transfer
 certifi==2020.12.5
     # via requests
-cffi==1.13.2
+cffi==1.14.4
     # via
     #   -r requirements/developer.pip
     #   bcrypt
@@ -44,11 +44,11 @@ click==7.0
     # via
     #   -r requirements/developer.pip
     #   flintrock
-coverage==5.0.1
+coverage==5.4
     # via
     #   -r requirements/developer.pip
     #   pytest-cov
-cryptography==2.8
+cryptography==3.4.2
     # via
     #   -r requirements/developer.pip
     #   flintrock
@@ -64,13 +64,17 @@ freezegun==1.1.0
     # via -r requirements/developer.pip
 idna==2.10
     # via requests
-importlib-metadata==1.3.0
+importlib-metadata==3.4.0
     # via
     #   -r requirements/developer.pip
     #   keyring
     #   pluggy
     #   pytest
-jmespath==0.9.4
+iniconfig==1.1.1
+    # via
+    #   -r requirements/developer.pip
+    #   pytest
+jmespath==0.10.0
     # via
     #   -r requirements/developer.pip
     #   boto3
@@ -83,12 +87,7 @@ mccabe==0.6.1
     # via
     #   -r requirements/developer.pip
     #   flake8
-more-itertools==8.0.2
-    # via
-    #   -r requirements/developer.pip
-    #   pytest
-    #   zipp
-packaging==19.2
+packaging==20.9
     # via
     #   -r requirements/developer.pip
     #   bleach
@@ -103,7 +102,7 @@ pluggy==0.13.1
     # via
     #   -r requirements/developer.pip
     #   pytest
-py==1.8.0
+py==1.10.0
     # via
     #   -r requirements/developer.pip
     #   pytest
@@ -111,7 +110,7 @@ pycodestyle==2.3.1
     # via
     #   -r requirements/developer.pip
     #   flake8
-pycparser==2.19
+pycparser==2.20
     # via
     #   -r requirements/developer.pip
     #   cffi
@@ -123,17 +122,17 @@ pygments==2.7.4
     # via readme-renderer
 pyinstaller==3.5
     # via -r requirements/maintainer.in
-pynacl==1.3.0
+pynacl==1.4.0
     # via
     #   -r requirements/developer.pip
     #   paramiko
-pyparsing==2.4.6
+pyparsing==2.4.7
     # via
     #   -r requirements/developer.pip
     #   packaging
-pytest-cov==2.8.1
+pytest-cov==2.11.1
     # via -r requirements/developer.pip
-pytest==5.3.2
+pytest==6.2.2
     # via
     #   -r requirements/developer.pip
     #   pytest-cov
@@ -158,34 +157,36 @@ s3transfer==0.2.1
     # via
     #   -r requirements/developer.pip
     #   boto3
-six==1.13.0
+six==1.15.0
     # via
     #   -r requirements/developer.pip
     #   bcrypt
     #   bleach
-    #   cryptography
-    #   packaging
     #   pynacl
     #   python-dateutil
     #   readme-renderer
+toml==0.10.2
+    # via
+    #   -r requirements/developer.pip
+    #   pytest
 tqdm==4.56.0
     # via twine
 twine==1.15.0
     # via -r requirements/maintainer.in
-urllib3==1.25.7
+typing-extensions==3.7.4.3
+    # via
+    #   -r requirements/developer.pip
+    #   importlib-metadata
+urllib3==1.25.11
     # via
     #   -r requirements/developer.pip
     #   botocore
     #   requests
-wcwidth==0.1.7
-    # via
-    #   -r requirements/developer.pip
-    #   pytest
 webencodings==0.5.1
     # via bleach
 wheel==0.36.2
     # via -r requirements/maintainer.in
-zipp==0.6.0
+zipp==3.4.0
     # via
     #   -r requirements/developer.pip
     #   importlib-metadata

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -67,7 +67,6 @@ idna==2.10
 importlib-metadata==3.4.0
     # via
     #   -r requirements/developer.pip
-    #   keyring
     #   pluggy
     #   pytest
 iniconfig==1.1.1
@@ -79,8 +78,6 @@ jmespath==0.10.0
     #   -r requirements/developer.pip
     #   boto3
     #   botocore
-keyring==20.0.1
-    # via -r requirements/maintainer.in
 macholib==1.14
     # via pyinstaller
 mccabe==0.6.1

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -58,7 +58,7 @@ docutils==0.15.2
     #   -r requirements/developer.pip
     #   botocore
     #   readme-renderer
-flake8==3.5.0
+flake8==3.8.4
     # via -r requirements/developer.pip
 freezegun==1.1.0
     # via -r requirements/developer.pip
@@ -67,6 +67,7 @@ idna==2.10
 importlib-metadata==3.4.0
     # via
     #   -r requirements/developer.pip
+    #   flake8
     #   pluggy
     #   pytest
 iniconfig==1.1.1
@@ -103,7 +104,7 @@ py==1.10.0
     # via
     #   -r requirements/developer.pip
     #   pytest
-pycodestyle==2.3.1
+pycodestyle==2.6.0
     # via
     #   -r requirements/developer.pip
     #   flake8
@@ -111,7 +112,7 @@ pycparser==2.20
     # via
     #   -r requirements/developer.pip
     #   cffi
-pyflakes==1.6.0
+pyflakes==2.2.0
     # via
     #   -r requirements/developer.pip
     #   flake8

--- a/requirements/user.pip
+++ b/requirements/user.pip
@@ -5,19 +5,49 @@
 #    pip-compile --output-file=requirements/user.pip requirements/user.in
 #
 -e file:.#egg=Flintrock
-bcrypt==3.1.7             # via paramiko
+    # via -r requirements/user.in
+bcrypt==3.2.0
+    # via paramiko
 boto3==1.10.45
-botocore==1.13.45         # via boto3, s3transfer
-cffi==1.13.2              # via bcrypt, cryptography, pynacl
+    # via flintrock
+botocore==1.13.45
+    # via
+    #   boto3
+    #   flintrock
+    #   s3transfer
+cffi==1.14.4
+    # via
+    #   bcrypt
+    #   cryptography
+    #   pynacl
 click==7.0
-cryptography==2.8         # via paramiko
-docutils==0.15.2          # via botocore
-jmespath==0.9.4           # via boto3, botocore
+    # via flintrock
+cryptography==3.4.2
+    # via
+    #   flintrock
+    #   paramiko
+docutils==0.15.2
+    # via botocore
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
 paramiko==2.7.1
-pycparser==2.19           # via cffi
-pynacl==1.3.0             # via paramiko
-python-dateutil==2.8.1    # via botocore
+    # via flintrock
+pycparser==2.20
+    # via cffi
+pynacl==1.4.0
+    # via paramiko
+python-dateutil==2.8.1
+    # via botocore
 pyyaml==5.2
-s3transfer==0.2.1         # via boto3
-six==1.13.0               # via bcrypt, cryptography, pynacl, python-dateutil
-urllib3==1.25.7           # via botocore
+    # via flintrock
+s3transfer==0.2.1
+    # via boto3
+six==1.15.0
+    # via
+    #   bcrypt
+    #   pynacl
+    #   python-dateutil
+urllib3==1.25.11
+    # via botocore

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,9 @@ addopts = --verbose --cov flintrock --cov-report html -rs
 [flake8]
 max-line-length = 100
 exclude = venv, build, dist
-ignore = E501
+ignore =
+    E501
+    E252
+    F821
+    F841
+    W503

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     author='Nicholas Chammas',
     author_email='nicholas.chammas@gmail.com',
     license='Apache License 2.0',
-    python_requires='>= 3.5',
+    python_requires='>= 3.6',
 
     # See: https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ The instructions here assume the following things:
 
 1. You've read through our [guide on contributing code](../CONTRIBUTING.md#contributing-code) and installed Flintrock's development dependencies.
 2. You're working from Flintrock's root directory.
-3. You're running Python 3.5+.
+3. You're running Python 3.6+.
 4. You've already setup your Flintrock config file and can launch clusters.
 
 To run all of Flintrock's tests that don't require AWS credentials, just run:

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -2,7 +2,6 @@ import glob
 import os
 import shutil
 import subprocess
-import sys
 
 from conftest import aws_credentials_required
 

--- a/tests/test_pyinstaller_packaging.py
+++ b/tests/test_pyinstaller_packaging.py
@@ -29,7 +29,6 @@ def pyinstaller_flintrock():
     return flintrock_executable_path
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ is required")
 @pytest.mark.skipif(not pyinstaller_exists(), reason="PyInstaller is required")
 def test_pyinstaller_flintrock_help(pyinstaller_flintrock):
     p = subprocess.run(
@@ -46,7 +45,6 @@ def test_pyinstaller_flintrock_help(pyinstaller_flintrock):
     assert p.returncode == 0
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ is required")
 @pytest.mark.skipif(not pyinstaller_exists(), reason="PyInstaller is required")
 @aws_credentials_required
 def test_pyinstaller_flintrock_describe(pyinstaller_flintrock):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import sys
 import tempfile
 
 import pytest

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -26,7 +26,6 @@ def tgz_file(request):
     return tgz_file_name
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ is required")
 @pytest.mark.parametrize('python', ['python', 'python2'])
 def test_download_package(python, project_root_dir, tgz_file):
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Included in this PR:
* Specify a recommended pip-tools version in the CONTRIBUTING guide so we evolve the compiled requirements file formats more deliberately.
* Drop Python 3.5 support.
* Test against Python 3.8 and 3.9.
* Bump transitive dependencies.