### PR TITLE
Bump paramiko

### DIFF
--- a/requirements/developer.pip
+++ b/requirements/developer.pip
@@ -63,7 +63,7 @@ mccabe==0.6.1
     # via flake8
 packaging==20.9
     # via pytest
-paramiko==2.7.1
+paramiko==2.7.2
     # via
     #   -r requirements/user.pip
     #   flintrock

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -91,7 +91,7 @@ packaging==20.9
     #   -r requirements/developer.pip
     #   bleach
     #   pytest
-paramiko==2.7.1
+paramiko==2.7.2
     # via
     #   -r requirements/developer.pip
     #   flintrock

--- a/requirements/user.pip
+++ b/requirements/user.pip
@@ -32,7 +32,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-paramiko==2.7.1
+paramiko==2.7.2
     # via flintrock
 pycparser==2.20
     # via cffi

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
         'boto3 == 1.10.45',
         'botocore == 1.13.45',
         'click == 7.0',
-        'paramiko == 2.7.1',
+        'paramiko == 2.7.2',
         'PyYAML == 5.2',
         # This is to address reports that PyInstaller-packaged versions
         # of Flintrock intermittently fail due to an out-of-date version


### PR DESCRIPTION
It seems there are some [fixes in Paramiko 2.7.2](https://www.paramiko.org/changelog.html) related to handling of private keys.

Fixes #327.