### PR TITLE
Bump default service versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Here's a quick way to launch a cluster on EC2, assuming you already have an [AWS
 ```sh
 flintrock launch test-cluster \
     --num-slaves 1 \
-    --spark-version 2.4.5 \
+    --spark-version 3.0.1 \
     --ec2-key-name key_name \
     --ec2-identity-file /path/to/key.pem \
     --ec2-ami ami-00b882ac5193044e4 \
@@ -252,7 +252,7 @@ provider: ec2
 
 services:
   spark:
-    version: 2.4.5
+    version: 3.0.1
 
 launch:
   num-slaves: 1

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ flintrock launch test-cluster \
     --spark-version 3.0.1 \
     --ec2-key-name key_name \
     --ec2-identity-file /path/to/key.pem \
-    --ec2-ami ami-00b882ac5193044e4 \
+    --ec2-ami ami-0beafb294c86717a8 \
     --ec2-user ec2-user
 ```
 
@@ -263,7 +263,7 @@ providers:
     identity-file: /path/to/.ssh/key.pem
     instance-type: m5.large
     region: us-east-1
-    ami: ami-00b882ac5193044e4
+    ami: ami-0beafb294c86717a8
     user: ec2-user
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,18 +87,18 @@ these steps:
    better performance.
 3. Make sure Flintrock is configured to use Hadoop/HDFS 2.7+. Earlier
    versions of Hadoop do not have solid implementations of `s3a://`.
-   Flintrock's default is Hadoop 2.8.5, so you don't need to do anything
+   Flintrock's default is Hadoop 3.3.0, so you don't need to do anything
    here if you're using a vanilla configuration.
 4. Call Spark with the hadoop-aws package to enable `s3a://`. For example:
    ```sh
-   spark-submit --packages org.apache.hadoop:hadoop-aws:2.7.6 my-app.py
-   pyspark --packages org.apache.hadoop:hadoop-aws:2.7.6
+   spark-submit --packages org.apache.hadoop:hadoop-aws:3.3.0 my-app.py
+   pyspark --packages org.apache.hadoop:hadoop-aws:3.3.0
    ```
    If you have issues using the package, consult the [hadoop-aws troubleshooting
    guide](http://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html)
    and try adjusting the version. As a rule of thumb, you should match the version
    of hadoop-aws to the version of Hadoop that Spark was built against (which is
-   typically Hadoop 2.7), even if the version of Hadoop that you're deploying to
+   typically Hadoop 3.2 or 2.7), even if the version of Hadoop that you're deploying to
    your Flintrock cluster is different.
 
 With this approach you don't need to copy around your AWS credentials

--- a/flintrock/__init__.py
+++ b/flintrock/__init__.py
@@ -1,2 +1,2 @@
 # See: https://packaging.python.org/en/latest/distributing/#standards-compliance-for-interoperability
-__version__ = '1.1.0.dev0'
+__version__ = '2.0.0.dev0'

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -12,7 +12,7 @@ services:
     # download-source: "s3://some-bucket/spark/{v}/spark-{v}.tgz"
     # executor-instances: 1
   hdfs:
-    version: 2.8.5
+    version: 3.3.0
     # optional; defaults to download from a dynamically selected Apache mirror
     #   - can be http, https, or s3 URL
     #   - must contain a {v} template corresponding to the version

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -30,7 +30,7 @@ providers:
     instance-type: m5.large
     region: us-east-1
     # availability-zone: <name>
-    ami: ami-00b882ac5193044e4  # Amazon Linux 2, us-east-1
+    ami: ami-0beafb294c86717a8  # Amazon Linux 2, us-east-1
     user: ec2-user
     # ami: ami-61bbf104  # CentOS 7, us-east-1
     # user: centos

--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -1,6 +1,6 @@
 services:
   spark:
-    version: 2.4.5
+    version: 3.0.1
     # git-commit: latest  # if not 'latest', provide a full commit SHA; e.g. d6dc12ef0146ae409834c78737c116050961f350
     # git-repository:  # optional; defaults to https://github.com/apache/spark
     # optional; defaults to download from a dynamically selected Apache mirror

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -255,7 +255,7 @@ def cli(cli_context, config, provider, debug):
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
 @click.option('--java-version', type=click.IntRange(min=8), default=8)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
-@click.option('--hdfs-version', default='2.8.5')
+@click.option('--hdfs-version', default='3.3.0')
 @click.option('--hdfs-download-source',
               help=(
                   "URL to download Hadoop from. If an S3 URL, Flintrock will use the "

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -253,7 +253,7 @@ def cli(cli_context, config, provider, debug):
 @cli.command()
 @click.argument('cluster-name')
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
-@click.option('--java-version', type=click.IntRange(min=8), default=8)
+@click.option('--java-version', type=click.IntRange(min=8), default=11)
 @click.option('--install-hdfs/--no-install-hdfs', default=False)
 @click.option('--hdfs-version', default='3.3.0')
 @click.option('--hdfs-download-source',
@@ -723,7 +723,7 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 
 @cli.command(name='add-slaves')
 @click.argument('cluster-name')
-@click.option('--java-version', type=click.IntRange(min=8), default=8)
+@click.option('--java-version', type=click.IntRange(min=8), default=11)
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -278,7 +278,7 @@ def cli(cli_context, config, provider, debug):
                   "URL to download Spark from. If an S3 URL, Flintrock will use the "
                   "AWS CLI from the cluster nodes to download it."
               ),
-              default='https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-{v}/spark-{v}-bin-hadoop2.7.tgz',
+              default='https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-{v}/spark-{v}-bin-hadoop3.2.tgz',
               show_default=True,
               callback=build_spark_download_url)
 @click.option('--spark-git-commit',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,7 +16,7 @@ FLINTROCK_ROOT_DIR = (
 @pytest.mark.parametrize(
     'spark_version', [
         (''),
-        ('2.4.5'),
+        ('3.0.1'),
         ('0626b11147133b67b26a04b4819f61a33dd958d3'),
     ])
 def test_templates(dummy_cluster, spark_version):

--- a/tests/test_flintrock.py
+++ b/tests/test_flintrock.py
@@ -157,7 +157,7 @@ def test_get_latest_commit():
     raises=Error,
 )
 def test_validate_valid_download_source():
-    validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz")
+    validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz")
     validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-3.0.1/spark-3.0.1-bin-hadoop2.7.tgz")
 
 

--- a/tests/test_flintrock.py
+++ b/tests/test_flintrock.py
@@ -158,7 +158,7 @@ def test_get_latest_commit():
 )
 def test_validate_valid_download_source():
     validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz")
-    validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-3.0.1/spark-3.0.1-bin-hadoop2.7.tgz")
+    validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-3.0.1/spark-3.0.1-bin-hadoop3.2.tgz")
 
 
 def test_validate_invalid_download_source():

--- a/tests/test_flintrock.py
+++ b/tests/test_flintrock.py
@@ -158,7 +158,7 @@ def test_get_latest_commit():
 )
 def test_validate_valid_download_source():
     validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz")
-    validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz")
+    validate_download_source("https://www.apache.org/dyn/closer.lua?action=download&filename=spark/spark-3.0.1/spark-3.0.1-bin-hadoop2.7.tgz")
 
 
 def test_validate_invalid_download_source():


### PR DESCRIPTION
Hadoop, Spark, Java, and Amazon Linux 2.

Since the default service versions are crossing a big boundary (Spark 2 -> 3; Java 8 -> 11), let's also bump Flintrock's major version.