### PR TITLE
Track Java version in cluster manifest

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -249,7 +249,6 @@ class EC2Cluster(FlintrockCluster):
             user: str,
             identity_file: str,
             num_slaves: int,
-            java_version: int,
             spot_price: float,
             spot_request_duration: str,
             min_root_ebs_size_gb: int,
@@ -334,7 +333,6 @@ class EC2Cluster(FlintrockCluster):
             super().add_slaves(
                 user=user,
                 identity_file=identity_file,
-                java_version=java_version,
                 new_hosts=new_slaves)
         except (Exception, KeyboardInterrupt) as e:
             if isinstance(e, InterruptedEC2Operation):

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -723,7 +723,6 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 
 @cli.command(name='add-slaves')
 @click.argument('cluster-name')
-@click.option('--java-version', type=click.IntRange(min=8), default=11)
 @click.option('--num-slaves', type=click.IntRange(min=1), required=True)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
 @click.option('--ec2-vpc-id', default='', help="Leave empty for default VPC.")
@@ -745,7 +744,6 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
 def add_slaves(
         cli_context,
         cluster_name,
-        java_version,
         num_slaves,
         ec2_region,
         ec2_vpc_id,
@@ -805,7 +803,6 @@ def add_slaves(
         cluster.add_slaves(
             user=user,
             identity_file=identity_file,
-            java_version=java_version,
             num_slaves=num_slaves,
             assume_yes=assume_yes,
             **provider_options)


### PR DESCRIPTION
Oversight on my part. `add-slaves` should not have or need the ability to specify a Java version. It should source it from the cluster manifest, guaranteeing that all added slaves have the same configuration as the existing cluster.

This matches the behavior of `add-slaves` in regards to picking the appropriate version of Hadoop or Spark to install on the new nodes.

Potential future improvement: Make Java a "service" like Hadoop and Spark, and reuse the cluster provisioning abstractions already built for them. Will need to build a way to express service dependencies (e.g. Spark depends on Java) so they get installed in the correct order.

Follow-up to #316.