### PR TITLE
Make finding cluster nodes more reliable in the face of launch failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,12 @@
 ### Changed
 
 * [#348]: Bumped default Spark to 3.2; dropped support for Python 3.6; added CI build for Python 3.10.
-* [#361]: Migrated from AdoptOpenJDK, which is deprecated, to Adoptium Open JDK.
+* [#361]: Migrated from AdoptOpenJDK, which is deprecated, to Adoptium OpenJDK.
+* [#362]: Improved Flintrock's ability to cleanup after launch failures.
 
 [#348]: https://github.com/nchammas/flintrock/pull/348
 [#361]: https://github.com/nchammas/flintrock/pull/361
+[#362]: https://github.com/nchammas/flintrock/pull/362
 
 ## [2.0.0] - 2021-06-10
 

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -915,7 +915,6 @@ def launch(
     else:
         instance_profile_arn = ''
 
-    num_instances = num_slaves + 1
     if user_data is not None:
         user_data = user_data.read()
     else:

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -810,6 +810,7 @@ def _create_instances(
             cluster_instances = ec2.create_instances(
                 MinCount=num_instances,
                 MaxCount=num_instances,
+                # Shutdown Behavior is specific to on-demand instances.
                 InstanceInitiatedShutdownBehavior=instance_initiated_shutdown_behavior,
                 **common_launch_specs,
             )

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -195,6 +195,7 @@ class EC2Cluster(FlintrockCluster):
         for instance in self.instances:
             instance.modify_attribute(
                 Groups=[flintrock_base_group.id])
+        time.sleep(1)
 
         # TODO: Centralize logic to get cluster security group name from cluster name.
         cluster_group = list(
@@ -814,7 +815,9 @@ def _create_instances(
                 InstanceInitiatedShutdownBehavior=instance_initiated_shutdown_behavior,
                 **common_launch_specs,
             )
-        time.sleep(10)  # AWS metadata eventual consistency tax.
+        # AWS metadata eventual consistency tax.
+        # Do we need such a long wait here?
+        time.sleep(3)
         return cluster_instances
     except (Exception, KeyboardInterrupt) as e:
         if not isinstance(e, KeyboardInterrupt):

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -793,11 +793,6 @@ def _create_instances(
                         {'Name': 'instance-id', 'Values': [r['InstanceId'] for r in spot_requests]}
                     ]))
         else:
-            # Move this to flintrock.py?
-            logger.info("Launching {c} instance{s}...".format(
-                c=num_instances,
-                s='' if num_instances == 1 else 's'))
-
             cluster_instances = ec2.create_instances(
                 MinCount=num_instances,
                 MaxCount=num_instances,

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -269,16 +269,17 @@ class EC2Cluster(FlintrockCluster):
 
     @timeit
     def add_slaves(
-            self,
-            *,
-            user: str,
-            identity_file: str,
-            num_slaves: int,
-            spot_price: float,
-            spot_request_duration: str,
-            min_root_ebs_size_gb: int,
-            tags: list,
-            assume_yes: bool):
+        self,
+        *,
+        user: str,
+        identity_file: str,
+        num_slaves: int,
+        spot_price: float,
+        spot_request_duration: str,
+        min_root_ebs_size_gb: int,
+        tags: list,
+        assume_yes: bool,
+    ):
         security_group_ids = [
             group['GroupId']
             for group in self.master_instance.security_groups]

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -7,6 +7,7 @@ import base64
 import logging
 from ipaddress import IPv4Network
 from datetime import datetime
+from typing import List, Tuple
 
 # External modules
 import boto3
@@ -1126,7 +1127,8 @@ def _get_cluster_name(instance: 'boto3.resources.factory.ec2.Instance') -> str:
 
 
 def _get_cluster_master_slaves(
-        instances: list) -> ('boto3.resources.factory.ec2.Instance', list):
+    instances: list
+) -> 'Tuple[boto3.resources.factory.ec2.Instance, List[boto3.resources.factory.ec2.Instance]]':
     """
     Get the master and slave instances from a set of raw EC2 instances representing
     a Flintrock cluster.

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -338,6 +338,7 @@ class EC2Cluster(FlintrockCluster):
                 user_data=user_data,
                 tag_specifications=_tag_specs(self.name, 'slave', tags),
             )
+            time.sleep(3)
 
             existing_slaves = self.slave_ips
 
@@ -804,9 +805,6 @@ def _create_instances(
                 InstanceInitiatedShutdownBehavior=instance_initiated_shutdown_behavior,
                 **common_launch_specs,
             )
-        # AWS metadata eventual consistency tax.
-        # Do we need such a long wait here?
-        time.sleep(3)
         return cluster_instances
     except (Exception, KeyboardInterrupt) as e:
         if not isinstance(e, KeyboardInterrupt):
@@ -960,6 +958,7 @@ def launch(
             tag_specifications=slave_tags,
             **common_instance_spec,
         )
+        time.sleep(3)
 
         cluster = EC2Cluster(
             name=cluster_name,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -490,6 +490,11 @@ def launch(
             )
         services += [spark]
 
+    logger.info(
+        "Launching 1 master and {n} slave{s}...".format(
+            n=num_slaves,
+            s='' if num_slaves == 1 else 's',
+        ))
     if provider == 'ec2':
         cluster = ec2.launch(
             cluster_name=cluster_name,
@@ -822,6 +827,11 @@ def add_slaves(
             '--ec2-user'],
         scope=locals())
 
+    logger.info(
+        "Launching {n} slave{s}...".format(
+            n=num_slaves,
+            s='' if num_slaves == 1 else 's',
+        ))
     if provider == 'ec2':
         cluster = ec2.get_cluster(
             cluster_name=cluster_name,


### PR DESCRIPTION
As suggested in #339, this PR updates Flintrock so that it tags launched nodes as part of the launch itself, rather than in a separate call post-launch. This means that we can always rely on tags to find cluster nodes, even when a launch operation fails midway.

This PR also:
* Adjusts when and how long we wait for AWS to process launch requests before proceeding with other operations.
* Tweaks the message Flintrock prints when launching nodes.
* Makes some formatting changes. (At this point I am inclined to reformat the entire repo with `black` or something similar.)

I tested this PR by launching and destroying clusters, and interrupting cluster launches at various points to test Flintrock's ability to find the half-baked nodes.

Fixes #183.
Fixes #339.
Related to #179.
