### PR TITLE
Enhance tag checking with consolidated error handling

### DIFF
--- a/flintrock/exceptions.py
+++ b/flintrock/exceptions.py
@@ -17,6 +17,16 @@ class Error(Exception):
     pass
 
 
+class SlackUsernameNotFound(Error):
+    """Exception raised when the SLACK_USERNAME is not found in the configuration."""
+    pass
+
+
+class TeamDataNotFound(Error):
+    """Exception raised when the TEAM,DATA is not found in the configuration."""
+    pass
+
+
 class ClusterNotFound(Error):
     pass
 


### PR DESCRIPTION
Enhance tag checking with consolidated error handling

This PR makes the following changes:
* Error when the tag USERNAME is not existing in the flintrock configuration
* Error when the value of the tag TEAM is not DATA in the flintrock configuration 
