### PR TITLE
chore: bump pyyaml to build with py3.13

### DIFF
--- a/requirements/developer.pip
+++ b/requirements/developer.pip
@@ -80,7 +80,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/user.pip
     #   botocore
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements/user.pip
     #   flintrock

--- a/requirements/maintainer.pip
+++ b/requirements/maintainer.pip
@@ -147,7 +147,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/developer.pip
     #   botocore
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements/developer.pip
     #   flintrock

--- a/requirements/user.pip
+++ b/requirements/user.pip
@@ -35,7 +35,7 @@ pynacl==1.5.0
     # via paramiko
 python-dateutil==2.8.2
     # via botocore
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via flintrock
 s3transfer==0.7.0
     # via boto3

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         'botocore == 1.32.4',
         'click == 8.1.7',
         'paramiko == 3.4.0',
-        'PyYAML == 6.0.1',
+        'PyYAML == 6.0.2',
     ],
 
     entry_points={


### PR DESCRIPTION
This PR makes the following changes:
*  bump pyyaml to build with py3.13

relates to https://github.com/Homebrew/homebrew-core/pull/194055
