### PR TITLE
Bump macOS GitHub runner from 11 to 14

### DIFF
--- a/.github/workflows/flintrock.yaml
+++ b/.github/workflows/flintrock.yaml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
       - run: "pip install -r requirements/maintainer.pip"
       - run: "pytest"
       - run: python -m build

--- a/.github/workflows/flintrock.yaml
+++ b/.github/workflows/flintrock.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-11
+          - macos-14
         python-version:
           # Update the artifact upload steps below if modifying
           # this list of Python versions.


### PR DESCRIPTION
The `macos-11` runner has been [removed][1].

[1]: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/